### PR TITLE
Python 3 fixes for value.py

### DIFF
--- a/src-api/openzwave/value.py
+++ b/src-api/openzwave/value.py
@@ -30,6 +30,13 @@ except ImportError:
     pass
 from openzwave.object import ZWaveObject
 
+try:
+    # Python 2
+    basestring
+except NameError:
+    # Python 3
+    basestring = str
+
 # Set default logging handler to avoid "No handler found" warnings.
 import logging
 try:  # Python 2.7+


### PR DESCRIPTION
Python 3 does not know the concept of a base string, just str. This PR fixes this.