### PR TITLE
Makes sed command compatible with BSD and GNU sed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ openzwave:
 	git clone git://github.com/OpenZWave/open-zwave.git openzwave
 
 openzwave/libopenzwave.a: openzwave
-	sed -i '253s/.*//' openzwave/cpp/src/value_classes/ValueID.h
+	sed -i -e '253s/.*//' openzwave/cpp/src/value_classes/ValueID.h
 	cd openzwave && make
 
 clean-archive:


### PR DESCRIPTION
Default OS X uses BSD sed, which requires the -e parameter. It is compatible
with GNU sed, so this works on both.
