### PR TITLE
Updated cython wrappers of ValueID enums for Cython 0.23 (Fixes #10)

### DIFF
--- a/src-lib/libopenzwave/values.pxd
+++ b/src-lib/libopenzwave/values.pxd
@@ -19,7 +19,7 @@ along with python-openzwave. If not, see http://www.gnu.org/licenses.
 """
 from libc.stdint cimport uint32_t, uint64_t, int32_t, int16_t, uint8_t, int8_t
 
-cdef extern from "ValueID.h" namespace "OpenZWave":
+cdef extern from "ValueID.h" namespace "OpenZWave::ValueID":
 
     cdef enum ValueGenre:
         ValueGenre_Basic = 0                # The 'level' as controlled by basic commands.  Usually duplicated by another command class.
@@ -40,7 +40,7 @@ cdef extern from "ValueID.h" namespace "OpenZWave":
         ValueType_Button = 8                # A write-only value that is the equivalent of pressing a button to send a command to a device
         ValueType_Raw = 9                   # Used as a list of Bytes
         ValueType_Max = ValueType_Raw       # The highest-number type defined.  Not to be used as a type itself.
-
+cdef extern from "ValueID.h" namespace "OpenZWave":
     cdef cppclass ValueID:
         uint32_t GetHomeId()
         uint8_t GetNodeId()


### PR DESCRIPTION
This update is required by changes made in Cython 0.23. 
