### PR TITLE
Fixed issue where in Python3, all strings were bytes, not strings.

### DIFF
--- a/src-lib/libopenzwave/libopenzwave.pyx
+++ b/src-lib/libopenzwave/libopenzwave.pyx
@@ -94,7 +94,10 @@ cdef string str_to_cppstr(str s):
 cdef cstr_to_str(s):
     if six.PY3 and not isinstance(s, str):
         return s.decode('utf-8')
-    return s.encode('utf-8')
+    elif six.PY3:
+        return s
+    else:
+        return s.encode('utf-8')
 
 class LibZWaveException(Exception):
     """

--- a/tests/api/test_sensor.py
+++ b/tests/api/test_sensor.py
@@ -121,6 +121,16 @@ class TestSensor(TestApi):
                 self.assertTrue(good)
         if not ran :
             self.skipTest("No Decimal sensor found")
+            
+    def test_510_sensor_label(self):
+        ran = False
+        for node in self.network.nodes:
+            for sensorid, sensor in self.network.nodes[node].get_sensors().items():
+                ran = True
+                label = sensor.label
+                self.assertTrue(isinstance(label, str))
+        if not ran :
+            self.skipTest("No sensor found")
 
 if __name__ == '__main__':
     sys.argv.append('-v')


### PR DESCRIPTION
The changes made in [here](https://github.com/OpenZWave/python-openzwave/commit/d14f1a479c1f87875c67e65d046983692c4e307b) started returning `b'bytes types'` instead of `'string types'` for strings like sensor labels and whatnot. This broke things in, for example, [home-assistant](https://github.com/balloob/home-assistant/issues/817). It was only broken in situations where a string was passed to it, which then got encoded to utf-8, which in Python3 makes it a `bytes` type (opposite of Python2, go figure). 

In this PR, I updated the string conversion method and tested it. It works and does return strings again for python3. Python2 behavior is unchanged. I also added a unit test that failed before this PR and passes after it. This will help ensure downstream stuff doesn't break again. 
