### PR TITLE
add RGB Bulbs API

### DIFF
--- a/examples/api_demo.py
+++ b/examples/api_demo.py
@@ -207,6 +207,16 @@ for node in network.nodes:
         print("  id on the network : %s" % (network.nodes[node].values[val].id_on_network))
         print("  level: %s" % (network.nodes[node].get_dimmer_level(val)))
 print "------------------------------------------------------------"
+print "Retrieve RGB Bulbs on the network"
+print "------------------------------------------------------------"
+values = {}
+for node in network.nodes:
+    for val in network.nodes[node].get_rgbbulbs() :
+        print("node/name/index/instance : %s/%s/%s/%s" % (node,network.nodes[node].name,network.nodes[node].values[val].index,network.nodes[node].values[val].instance))
+        print("  label/help : %s/%s" % (network.nodes[node].values[val].label,network.nodes[node].values[val].help))
+        print("  id on the network : %s" % (network.nodes[node].values[val].id_on_network))
+        print("  level: %s" % (network.nodes[node].get_dimmer_level(val)))
+print "------------------------------------------------------------"
 print "Retrieve sensors on the network"
 print "------------------------------------------------------------"
 values = {}

--- a/src-api/openzwave/command.py
+++ b/src-api/openzwave/command.py
@@ -564,6 +564,43 @@ class ZWaveNodeSwitch(ZWaveNodeInterface):
             return self.values[value_id].data
         return None
 
+    def get_rgbbulbs(self):
+        """
+        The command 0x33 (COMMAND_CLASS_COLOR) of this node.
+        Retrieve the list of values to consider as RGBW bulbs.
+        Filter rules are :
+
+            command_class = 0x33
+            genre = "User"
+            type = "String"
+            readonly = False
+            writeonly = False
+
+        :return: The list of dimmers on this node
+        :rtype: dict()
+
+        """
+        return self.get_values(class_id=0x33, genre='User', \
+        type='String', readonly=False, writeonly=False)
+
+    def set_rgbw(self, value_id, value):
+        """
+        The command 0x33 (COMMAND_CLASS_COLOR) of this node.
+        Set RGBW to value (using value value_id).
+
+        :param value_id: The value to retrieve state
+        :type value_id: String
+        :param value: The level : a RGBW value 
+        :type value: int
+
+        """
+        logger.debug("set_rgbw value:%s", value)
+        if value_id in self.get_rgbbulbs():
+            self.values[value_id].data = value
+            return True
+        return False
+
+
 class ZWaveNodeSensor(ZWaveNodeInterface):
     """
     Represents an interface to Sensor Commands


### PR DESCRIPTION
Bonjour Sébastien,

Voici quelques petits ajouts permettant de contrôler les RGB Bulbs qui ont été ajoutés il y a quelques mois dans le code de OpenZWave.

J'ai fait quelques tests avec succès avec une Zipato RGBW.

Ciao !
