### PR TITLE
Remove sudo from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ repo-deps: common-deps cython-deps tests-deps pip-deps
 	@echo "Dependencies for users installed (python ${python_version_full})"
 
 autobuild-deps: common-deps cython-deps tests-deps pip-deps
-	sudo apt-get install -y git
+	apt-get install -y git
 	@echo
 	@echo "Dependencies for autobuilders (docker, travis, ...) installed (python ${python_version_full})"
 
@@ -130,46 +130,46 @@ arch-deps: common-deps pip-deps
 
 python-deps:
 ifeq (${python_version_major},2)
-	sudo apt-get install -y python2.7 python2.7-dev python2.7-minimal libyaml-dev python-pip
+	apt-get install -y python2.7 python2.7-dev python2.7-minimal libyaml-dev python-pip
 endif
 ifeq (${python_version_major},3)
-	sudo  apt-get install -y python3 python3-dev python3-minimal libyaml-dev python3-pip
+	apt-get install -y python3 python3-dev python3-minimal libyaml-dev python3-pip
 endif
 
 cython-deps:
 ifeq (${python_version_major},2)
-	sudo apt-get install -y cython
+	apt-get install -y cython
 endif
 ifeq (${python_version_major},3)
-	sudo  apt-get install -y cython3
+	apt-get install -y cython3
 endif
 
 common-deps:
 	@echo Installing dependencies for python : ${python_version_full}
 ifeq (${python_version_major},2)
-	sudo apt-get install -y python-pip python-dev python-docutils python-setuptools python-louie
+	apt-get install -y python-pip python-dev python-docutils python-setuptools python-louie
 endif
 ifeq (${python_version_major},3)
-	-sudo  apt-get install -y python3-pip python3-docutils python3-dev python3-setuptools
+	-apt-get install -y python3-pip python3-docutils python3-dev python3-setuptools
 endif
-	sudo apt-get install -y build-essential libudev-dev g++
+	apt-get install -y build-essential libudev-dev g++
 
 tests-deps:
-	sudo ${PIP_EXEC} install nose-html
-	sudo ${PIP_EXEC} install nose-progressive
-	sudo ${PIP_EXEC} install coverage
-	sudo ${PIP_EXEC} install nose
-	sudo ${PIP_EXEC} install pylint
+	${PIP_EXEC} install nose-html
+	${PIP_EXEC} install nose-progressive
+	${PIP_EXEC} install coverage
+	${PIP_EXEC} install nose
+	${PIP_EXEC} install pylint
 
 doc-deps:
-	-sudo  apt-get install -y python-sphinx
-	sudo ${PIP_EXEC} install sphinxcontrib-blockdiag sphinxcontrib-actdiag sphinxcontrib-nwdiag sphinxcontrib-seqdiag
+	-apt-get install -y python-sphinx
+	${PIP_EXEC} install sphinxcontrib-blockdiag sphinxcontrib-actdiag sphinxcontrib-nwdiag sphinxcontrib-seqdiag
 
 pip-deps:
-	#sudo ${PIP_EXEC} install docutils
-	#sudo ${PIP_EXEC} install setuptools
+	#${PIP_EXEC} install docutils
+	#${PIP_EXEC} install setuptools
 	#The following line crashes with a core dump
-	#sudo ${PIP_EXEC} install "Cython==0.22"
+	#${PIP_EXEC} install "Cython==0.22"
 
 merge-python3:
 	git checkout python3
@@ -214,18 +214,18 @@ docs: clean-docs
 	@echo "Documentation finished."
 
 install-lib: build
-	sudo ${PYTHON_EXEC} setup-lib.py install
+	${PYTHON_EXEC} setup-lib.py install
 	@echo
 	@echo "Installation of lib finished."
 
 install-api: install-lib
-	sudo ${PYTHON_EXEC} setup-api.py install
+	${PYTHON_EXEC} setup-api.py install
 	@echo
 	@echo "Installation of API finished."
 
 install: install-api
-	sudo ${PYTHON_EXEC} setup-manager.py install
-	sudo ${PYTHON_EXEC} setup-web.py install
+	${PYTHON_EXEC} setup-manager.py install
+	${PYTHON_EXEC} setup-web.py install
 	@echo
 	@echo "Installation for users finished."
 


### PR DESCRIPTION
It should be up to the user to run the Makefile with appropriate
permissions. Baking sudo commands in means the user installing
python-openzwave _must_ be a sudoer, which is not ideal. It prevents
an unprivileged user from installing python-openzwave in a virtualenv.
