### PR TITLE
fixes name urwid is not defined

### DIFF
--- a/src-manager/scripts/pyozw_shell
+++ b/src-manager/scripts/pyozw_shell
@@ -29,6 +29,7 @@ __author__ = 'bibi21000'
 
 import sys, os, optparse, re, shutil, datetime
 import logging
+import urwid
 from pyozwman.ozwsh_main import MainWindow
 from libopenzwave import configPath
 import signal


### PR DESCRIPTION
the urwid import seems to be missing resulting in `NameError: name 'urwid' is not defined` when I do `Ctrl+C`