### PR TITLE
Options path fixes

### DIFF
--- a/src-api/openzwave/option.py
+++ b/src-api/openzwave/option.py
@@ -48,7 +48,7 @@ class ZWaveOption(libopenzwave.PyOptions):
     Represents a Zwave option used to start the manager.
 
     """
-    def __init__(self, device=None, config_path=None, user_path=".", cmd_line=""):
+    def __init__(self, device=None, config_path=None, user_path=None, cmd_line=None):
         """
         Create an option object and check that parameters are valid.
 
@@ -80,8 +80,6 @@ class ZWaveOption(libopenzwave.PyOptions):
                 import sys, traceback
                 raise ZWaveException(u"Error when retrieving device %s : %s" % (device, traceback.format_exception(*sys.exc_info())))
         libopenzwave.PyOptions.__init__(self, config_path=config_path, user_path=user_path, cmd_line=cmd_line)
-        self._user_path = user_path
-        self._config_path = config_path
 
     def set_log_file(self, logfile):
         """

--- a/src-lib/libopenzwave/libopenzwave.pyx
+++ b/src-lib/libopenzwave/libopenzwave.pyx
@@ -646,13 +646,13 @@ cdef class PyOptions:
     Manage options manager
     """
 
-    cdef str _config_path
-    cdef str _user_path
-    cdef str _cmd_line
+    cdef readonly str _config_path
+    cdef readonly str _user_path
+    cdef readonly str _cmd_line
 
     cdef Options *options
 
-    def __init__(self, config_path=None, user_path=".", cmd_line=""):
+    def __init__(self, config_path=None, user_path=None, cmd_line=None):
         """
         Create an option object and check that parameters are valid.
 


### PR DESCRIPTION
This PR fixes a bug where the calculated config_path for ZWaveOption wasn't available on the config_path property. [These lines](https://github.com/OpenZWave/python-openzwave/compare/master...armills:options-paths?expand=1#diff-40deed1c431492857dff1582a316e0d2L83) worked correctly when a config/user path was passed in, but end up with the wrong value if config_path needs to be calculated by PyOptions. I changed the PyOptions variables to be readable by the parent class, so the properties can be exposed to the API.

I also eliminated the duplication of default values, since the final values will now be correctly passed back up to the parent.