### PR TITLE
Fix doc generations warnings and add missing door lock documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
 :orphan:
+
 .. image:: https://travis-ci.org/OpenZWave/python-openzwave.svg?branch=master
     :target: https://travis-ci.org/OpenZWave/python-openzwave
     :alt: Travis status

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,4 @@
+:orphan:
 .. image:: https://travis-ci.org/OpenZWave/python-openzwave.svg?branch=master
     :target: https://travis-ci.org/OpenZWave/python-openzwave
     :alt: Travis status

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,7 +43,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -E -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,4 +1,5 @@
 :orphan:
+
 .. image:: https://travis-ci.org/OpenZWave/python-openzwave.svg?branch=master
     :target: https://travis-ci.org/OpenZWave/python-openzwave
     :alt: Travis status

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,3 +1,4 @@
+:orphan:
 .. image:: https://travis-ci.org/OpenZWave/python-openzwave.svg?branch=master
     :target: https://travis-ci.org/OpenZWave/python-openzwave
     :alt: Travis status

--- a/docs/_index_txt.rst
+++ b/docs/_index_txt.rst
@@ -5,7 +5,6 @@
 * :doc:`Install from archive </INSTALL_ARCH>`
 * :doc:`Install for MacOs </INSTALL_MAC>`
 * :doc:`Install for Windows </INSTALL_WIN>`
-* :doc:`Manual installation </INSTALL_MAN>`
 * :doc:`Change log </CHANGELOG>`
 * :doc:`Examples </EXAMPLES>`
 * :doc:`Developpers notes </DEVEL>`

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -7,5 +7,5 @@ The commands to use with nodes.
     :maxdepth: 2
 
 .. automodule:: openzwave.command
-    :members: ZWaveNodeBasic, ZWaveNodeSwitch, ZWaveNodeSensor
+    :members: ZWaveNodeBasic, ZWaveNodeSwitch, ZWaveNodeSensor, ZWaveNodeDoorLock
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -257,3 +257,5 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
+
+suppress_warnings = ['image.nonlocal_uri']

--- a/docs/diagrams.rst
+++ b/docs/diagrams.rst
@@ -8,7 +8,7 @@ Full startup process
 ====================
 
 .. blockdiag::
-    :maxwidth: 600
+    :width: 600
 
     blockdiag StartupProcess {
       orientation = portrait;

--- a/docs/object.rst
+++ b/docs/object.rst
@@ -8,4 +8,4 @@ The low level object. Implements cache mechanism.
 
 .. automodule:: openzwave.object
     :members: ZWaveObject, ZWaveNodeInterface, ZWaveException, ZWaveTypeException,
-        ZWaveCacheException, ZWaveCommandClassException, NullLoggingHandler
+        ZWaveCacheException, ZWaveCommandClassException

--- a/src-api/openzwave/command.py
+++ b/src-api/openzwave/command.py
@@ -933,6 +933,7 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
         The command 0x62 (COMMAND_CLASS_DOOR_LOCK) of this node.
         Retrieves the list of values to consider as doorlocks.
         Filter rules are :
+
             command_class = 0x62
             genre = "User"
             type = "Bool"
@@ -940,6 +941,7 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
             writeonly = False
         :return: The list of door locks on this node
         :rtype: dict()
+
         """
         return self.get_values(class_id=0x62, genre='User', type='Bool', readonly=False, writeonly=False)
 
@@ -952,6 +954,7 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
         :type value_id: int
         :param value: True or False
         :type value: bool
+
         """
         if value_id in self.get_doorlocks():
             self.values[value_id].data = value
@@ -963,6 +966,7 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
         The command 0x63 (COMMAND_CLASS_USER_CODE) of this node.
         Retrieves the list of value to consider as usercodes.
         Filter rules are :
+
             command_class = 0x63
             genre = "User"
             type = "Raw"
@@ -970,6 +974,7 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
             writeonly = False
         :return: The list of user codes on this node
         :rtype: dict()
+
         """
         return self.get_values(class_id=0x63, type='Raw', genre='User', readonly=False, writeonly=False)
 
@@ -982,6 +987,7 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
         :type value_id: int
         :param value: User Code as string
         :type value: str
+
         """
         if value_id in self.get_usercodes():
             self.values[value_id].data = value
@@ -993,11 +999,13 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
         The command 0x4c (COMMAND_CLASS_DOOR_LOCK_LOGGING) of this node.
         Retrieves the value consisting of log records.
         Filter rules are :
+
             command_class = 0x4c
             genre = "User"
             type = "String"
             readonly = True
         :return: The dict of log records with value_id as key
         :rtype: dict()
+
         """
         return self.get_values(class_id=0x4c, type='String', genre='User', readonly=True)

--- a/src-api/openzwave/command.py
+++ b/src-api/openzwave/command.py
@@ -939,6 +939,7 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
             type = "Bool"
             readonly = False
             writeonly = False
+
         :return: The list of door locks on this node
         :rtype: dict()
 
@@ -972,6 +973,7 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
             type = "Raw"
             readonly = False
             writeonly = False
+
         :return: The list of user codes on this node
         :rtype: dict()
 
@@ -1004,6 +1006,7 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
             genre = "User"
             type = "String"
             readonly = True
+
         :return: The dict of log records with value_id as key
         :rtype: dict()
 

--- a/src-api/openzwave/command.py
+++ b/src-api/openzwave/command.py
@@ -623,7 +623,7 @@ class ZWaveNodeSwitch(ZWaveNodeInterface):
 
         :param value_id: The value to retrieve state
         :type value_id: String
-        :param value: The level : a RGBW value 
+        :param value: The level : a RGBW value
         :type value: int
 
         """
@@ -946,7 +946,8 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
     def set_doorlock(self, value_id, value):
         """
         The command 0x62 (COMMAND_CLASS_DOOR_LOCK) of this node.
-        Sets doorlock to value (using value_id)
+        Sets doorlock to value (using value_id).
+
         :param value_id: The value to retrieve state from
         :type value_id: int
         :param value: True or False
@@ -975,7 +976,8 @@ class ZWaveNodeDoorLock(ZWaveNodeInterface):
     def set_usercode(self, value_id, value):
         """
         The command 0x63 (COMMAND_CLASS_USER_CODE) of this node.
-        Sets usercode to value (using value_id)
+        Sets usercode to value (using value_id).
+
         :param value_id: The value to retrieve state from
         :type value_id: int
         :param value: User Code as string

--- a/src-api/openzwave/controller.py
+++ b/src-api/openzwave/controller.py
@@ -980,8 +980,10 @@ class ZWaveController(ZWaveObject):
                    })
 
     def request_controller_status(self):
-        """Generate a notification with the current status of the controller.
+        """
+        Generate a notification with the current status of the controller.
         You can check the lock in your code using something like this:
+
             if controllerState in network.controller.STATES_UNLOCKED:
                 hide_cancel_button()
                 show_command_buttons()


### PR DESCRIPTION
@bibi21000 I just cleaned up bunch of `make docs` warnings and updated few things. I forgot to add door lock in the list of automodules so added that as well. What do you think of hosting python-openzwave documentation on something like github page or readthedocs.io(unless there's one already)? I think that would be really helpful for everyone.