### PR TITLE
Revert "Options path fixes"

### DIFF
--- a/src-api/openzwave/option.py
+++ b/src-api/openzwave/option.py
@@ -48,7 +48,7 @@ class ZWaveOption(libopenzwave.PyOptions):
     Represents a Zwave option used to start the manager.
 
     """
-    def __init__(self, device=None, config_path=None, user_path=None, cmd_line=None):
+    def __init__(self, device=None, config_path=None, user_path=".", cmd_line=""):
         """
         Create an option object and check that parameters are valid.
 
@@ -80,6 +80,8 @@ class ZWaveOption(libopenzwave.PyOptions):
                 import sys, traceback
                 raise ZWaveException(u"Error when retrieving device %s : %s" % (device, traceback.format_exception(*sys.exc_info())))
         libopenzwave.PyOptions.__init__(self, config_path=config_path, user_path=user_path, cmd_line=cmd_line)
+        self._user_path = user_path
+        self._config_path = config_path
 
     def set_log_file(self, logfile):
         """

--- a/src-lib/libopenzwave/libopenzwave.pyx
+++ b/src-lib/libopenzwave/libopenzwave.pyx
@@ -646,13 +646,13 @@ cdef class PyOptions:
     Manage options manager
     """
 
-    cdef readonly str _config_path
-    cdef readonly str _user_path
-    cdef readonly str _cmd_line
+    cdef str _config_path
+    cdef str _user_path
+    cdef str _cmd_line
 
     cdef Options *options
 
-    def __init__(self, config_path=None, user_path=None, cmd_line=None):
+    def __init__(self, config_path=None, user_path=".", cmd_line=""):
         """
         Create an option object and check that parameters are valid.
 


### PR DESCRIPTION
Reverts OpenZWave/python-openzwave#82

======================================================================
ERROR: test suite for <class 'tests.api.test_value.TestValue'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sebastien/.local/lib/python2.7/site-packages/nose/suite.py", line 209, in run
    self.setUp()
  File "/home/sebastien/.local/lib/python2.7/site-packages/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/home/sebastien/.local/lib/python2.7/site-packages/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/home/sebastien/.local/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/sebastien/devel/python-openzwave/tests/api/common.py", line 72, in setUpClass
    self.network = ZWaveNetwork(self.options)
  File "/home/sebastien/devel/python-openzwave/src-api/openzwave/network.py", line 326, in __init__
    self.dbcon = lite.connect(os.path.join(self._options.user_path, 'pyozw.sqlite'), check_same_thread=False)
  File "/home/sebastien/devel/python-openzwave/src-api/openzwave/option.py", line 339, in user_path
    return self._user_path
AttributeError: 'ZWaveOption' object has no attribute '_user_path'
-------------------- >> begin captured logging << --------------------
openzwave: DEBUG: Create network object.
openzwave: DEBUG: Create network object.
openzwave: DEBUG: Create network object.
openzwave: DEBUG: Create network object.
openzwave: DEBUG: Create network object.
openzwave: DEBUG: Create network object.
openzwave: DEBUG: Create network object.
openzwave: DEBUG: Create network object.
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
