### PR TITLE
Check LOCAL_OPENZWAVE environment variable when doing dev setup.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ python-openzwave 0.4.0 is coming !!!
     - git_shared (experimental) : download sources from openzwave github, build and install them as module on the system.
       Python_openzwave use it. Need root access to install openzwave libs.
     - ozwdev and ozwdev_shared : use the dev branch of openzwave on github.
-    - dev : for python_openzwave developers
+    - dev : for python_openzwave developers. Look for openzwave sources in a local folder specified by the LOCAL_OPENZWAVE environment variable (defaults to 'openzwave').
 
    
  - Install it :

--- a/pyozw_setup.py
+++ b/pyozw_setup.py
@@ -54,7 +54,7 @@ import glob
 
 from pyozw_version import pyozw_version
 
-LOCAL_OPENZWAVE = 'openzwave'
+LOCAL_OPENZWAVE = os.getenv('LOCAL_OPENZWAVE', 'openzwave')
 
 SETUP_DIR = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
Would be useful to be able to specify exactly where the openzwave sources are when building with dev flavour.