### PR TITLE
Replaced unsupported long type with int

### DIFF
--- a/src-manager/pyozwman/ozwsh_widgets.py
+++ b/src-manager/pyozwman/ozwsh_widgets.py
@@ -1342,7 +1342,7 @@ class ValuesTree(OldestTree):
     def set(self, param, value):
         values = self.window.network.nodes[self.node_id].values
         try:
-            param = long(param)
+            param = int(param)
         except:
             ok = False
             for val in values:
@@ -1375,7 +1375,7 @@ class ValuesTree(OldestTree):
     def poll(self, param, value):
         values = self.window.network.nodes[self.node_id].values
         try:
-            param = long(param)
+            param = int(param)
         except:
             ok = False
             for val in values:
@@ -1975,7 +1975,7 @@ class SceneTree(OldestTree):
     def delete(self, value):
         valueid = None
         try:
-            valueid = long(value)
+            valueid = int(value)
         except:
             ok = False
             try:


### PR DESCRIPTION
The <long> type used in the implementation for python2 has been replaced with <int> for compatibility with both versions of python.