### PR TITLE
AppVeyor CI should upload Windows wheels artifacts to pypi

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   PYPI_USER:
-    secure: kgeLyy1J3zuxy0HgMOWs+g==
+    secure: yna6KiH2GE3Ka1G5a3TlUQ==
   PYPI_PASSWORD:
-    secure: nEA5O3KbmGk3KIsdy0MBSQ==
+    secure: UpISOsYyHdCzurReV6FcTA==
 
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -115,7 +115,7 @@ test_script:
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.
-  - path: dist/*
+  - path: dist\*
   - name: windowswheels
 
 deploy_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -115,8 +115,8 @@ test_script:
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.
-  - path: dist\*
-  - name: windowswheels
+  - path: dist/*
+    name: windowswheels
 
 deploy_script:
   - echo "Uploading wheels"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,9 @@
 environment:
+  PYPI_USER:
+    secure: kgeLyy1J3zuxy0HgMOWs+g==
+  PYPI_PASSWORD:
+    secure: nEA5O3KbmGk3KIsdy0MBSQ==
+
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
@@ -80,6 +85,7 @@ install:
   - "python -m pip install wheel"
   - "python -m pip install Cython six"
   - "python -m pip install nose"
+  - "python -m pip install twine"
 
   - ps: Write-Host "PYTHON_VERSION $env:PYTHON_VERSION"
 
@@ -109,8 +115,21 @@ test_script:
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.
-  - path: dist\*
+  - path: dist/*
+  - name: windowswheels
 
-#on_success:
-#  - TODO: upload the content of dist/*.whl to a public wheelhouse
-#
+deploy_script:
+  - echo "Uploading wheels"
+  # populate pypirc file for twine
+  - echo [distutils]                                  > %USERPROFILE%\\.pypirc
+  - echo index-servers =                             >> %USERPROFILE%\\.pypirc
+  - echo     pypi                                    >> %USERPROFILE%\\.pypirc
+  - echo [pypi]                                      >> %USERPROFILE%\\.pypirc
+  - echo repository=https://test.pypi.org/legacy/    >> %USERPROFILE%\\.pypirc
+  - echo username=%PYPI_USER%                        >> %USERPROFILE%\\.pypirc
+  - echo password=%PYPI_PASSWORD%                    >> %USERPROFILE%\\.pypirc
+  # upload to pypi for Windows
+  - set PATH=%BK_PATH%
+  - set HOME=%USERPROFILE%
+  - twine upload --skip-existing dist/*.whl
+  - echo "Finished Artifact Deployment"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,5 +131,5 @@ deploy_script:
   # upload to pypi for Windows
   - set PATH=%BK_PATH%
   - set HOME=%USERPROFILE%
-  - twine upload --skip-existing dist/*.whl
+  - twine upload --repository pypi --skip-existing dist/*.whl
   - echo "Finished Artifact Deployment"


### PR DESCRIPTION
This should allow Windows users to pip install prebuilt binaries instead of having a development 
environment setup and building locally.

This isn't fully ready to merge yet and I'm just trying to test AppVeyor pointing to https://test.pypi.org/legacy/ for the uploads.