### PR TITLE
Fix undefined names

### DIFF
--- a/tests/api/test_command.py
+++ b/tests/api/test_command.py
@@ -62,7 +62,8 @@ class TestCommand(TestApi):
         for node in self.active_nodes:
             for val in self.active_nodes[node].get_battery_levels() :
                 ran = True
-                self.assertTrue(isinstance(self.active_nodes[node].get_battery_level(val), integer_types))
+                self.assertTrue(isinstance(self.active_nodes[node].get_battery_level(val),
+                                           six.integer_types))
         if ran == False :
             self.skipTest("No battery found")
 

--- a/tests/api/test_switch.py
+++ b/tests/api/test_switch.py
@@ -26,7 +26,9 @@ along with python-openzwave. If not, see http://www.gnu.org/licenses.
 
 """
 
-import os, shutil
+import os
+import shutil
+import sys
 import time
 import unittest
 from pprint import pprint

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,12 +25,9 @@ along with python-openzwave. If not, see http://www.gnu.org/licenses.
 
 """
 
-#The common sleep dealy to wait for network
-#We wait 1*SLEEP for network.STATE_AWAKED
-#After that we wait 1*SLEEP for network.STATE_READY
-SLEEP = 45
-
-import sys, os
+import os
+import shutil
+import sys
 import time
 import unittest
 import threading
@@ -38,6 +35,11 @@ import logging
 import json
 #~ import bson
 import six
+
+#The common sleep dealy to wait for network
+#We wait 1*SLEEP for network.STATE_AWAKED
+#After that we wait 1*SLEEP for network.STATE_READY
+SLEEP = 45
 
 class SetEncoder(json.JSONEncoder):
     def default(self, obj):

--- a/tests/manager/autobuild/test_manager.py
+++ b/tests/manager/autobuild/test_manager.py
@@ -32,6 +32,7 @@ __email__ = 'bibi21000@gmail.com'
 import sys
 import time
 import logging
+import unittest
 
 from tests.manager.common import TestManager
 

--- a/tests/web/autobuild/test_web.py
+++ b/tests/web/autobuild/test_web.py
@@ -32,6 +32,7 @@ __email__ = 'bibi21000@gmail.com'
 import sys
 import time
 import logging
+import unittest
 
 #~ from tests.web.common import FlaskTestBase
 

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -32,6 +32,7 @@ __email__ = 'bibi21000@gmail.com'
 import sys
 import time
 import logging
+import unittest
 
 #~ from flask.ext.socketio import SocketIO, emit, join_room, leave_room, close_room, disconnect
 #~ from flask.ext.socketio.test_client import SocketIOTestClient


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/OpenZWave/python-openzwave on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tests/common.py:75:13: F821 undefined name 'shutil'
            shutil.rmtree(self.userpath)
            ^
./tests/web/test_server.py:84:5: F821 undefined name 'unittest'
    unittest.main()
    ^
./tests/web/autobuild/test_web.py:47:5: F821 undefined name 'unittest'
    unittest.main()
    ^
./tests/manager/autobuild/test_manager.py:46:5: F821 undefined name 'unittest'
    unittest.main()
    ^
./tests/api/test_switch.py:134:5: F821 undefined name 'sys'
    sys.argv.append('-v')
    ^
./tests/api/test_command.py:65:92: F821 undefined name 'integer_types'
                self.assertTrue(isinstance(self.active_nodes[node].get_battery_level(val), integer_types))
                                                                                           ^
6     F821 undefined name 'integer_types'
6
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
