### PR TITLE
new build system for windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,13 @@ environment:
 
   matrix:
 
+    # there are only 3 compilers used to compile python
+    # Python 3.5, 3.6 and 3.7 were compiled with MSVC 14 (VS2017)
+    # Python 3.3 and 3.4 were compiled with MSVC 10 (VS2010)
+    # Python 2.6, 2.7, 3.0, 3.1 and 3.2 were compiled with MSVC 9 (VS2008)
+    # because of the code incompatibility with python-openzwave and the MSVC 9
+    # compiler we are going to compile with MSVC 10 instead
+
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
@@ -22,34 +29,24 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "32"
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PYTHON: "C:\\Python37"
-      PYTHON_VERSION: "3.7.x"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.x"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,21 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
+# This is so you can login via RDP to the appveyor VM. I needed
+# to use this to isolate some issue with the build process for windows.
+# appveyor was nice enough to not transfer over all of the registry keys for
+# the build tools they have installed into the VM. So I had to locate ones
+# that were available that would provide data that would identify some of the
+# components needed to build openzwave and libopenzave on windows.
+
+# when you uncomment the lines below. after the build process has completed
+# failed or not the program will stop and not exit. It will display
+# ip:host, username (always appveyor) and a random password. This is what is
+# needed to log into the VM
+
+# on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 deploy:
   - provider: Environment
     name: production

--- a/pyozw_common.py
+++ b/pyozw_common.py
@@ -329,7 +329,7 @@ class build_clib(distutils.command.build_clib.build_clib):
     # and distutils.dir_util.mkpath defaults to a verbose level of 1 which
     # which prints out each and every directory it makes. This congests the
     # output unnecessarily.
-    def mkpath(self, name, mode=0777):
+    def mkpath(self, name, mode=0o777):
         distutils.dir_util.mkpath(
             name,
             mode,

--- a/pyozw_common.py
+++ b/pyozw_common.py
@@ -1,0 +1,402 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of **python-openzwave**
+project https://github.com/OpenZWave/python-openzwave.
+    :platform: Unix, Windows, MacOS X
+    :sinopsis: openzwave API
+.. moduleauthor: bibi21000 aka Sébastien GALLET <bibi21000@gmail.com>
+License : GPL(v3)
+**python-openzwave** is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+**python-openzwave** is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with python-openzwave. If not, see http://www.gnu.org/licenses.
+"""
+from __future__ import print_function
+import os
+import sys
+import shutil
+import threading
+import subprocess
+import distutils.core
+import distutils.command.build_clib
+import distutils.dir_util
+import distutils.errors
+import pyozw_version
+
+
+# read further down as to what this is for
+DLL_MAIN = '''
+
+void PyInit_OpenZwave() {}
+
+'''
+
+# this is an easy macro to tell if a debugging version of python is what is
+# running if it is what is running then we want to build a debugging version
+# of openzwave. the use of this will allow you to set any preprocessor
+# macros to build a debugging version of openzwave
+
+DEBUG_BUILD = os.path.splitext(sys.executable)[0].endswith('_d')
+
+# when building openzwave with distutils you will need to include the
+# python library file in the list of libraries. creates that filename for ya.
+PYTHON_LIB = (
+    'python%s%s' % (sys.hexversion >> 24, (sys.hexversion >> 16) & 0xff)
+)
+
+# this is a thread lock for printing. I use 10 threads in the windows
+# compilation of openzwave to compile it. it speeds up the build process a lot.
+# but we do not want to get the output all jumbled up so before printing
+# anything from the output buffer we use this lock before we print the
+# output buffer to stdout or stderr. we iterate over the output buffer line
+# by line so if this lock is not in place the lines that get printed would be
+# out of order.
+print_lock = threading.Lock()
+
+
+# in order to have distutils handle the building of openzwave there has to be
+# a call to PyInit so we create a cpp file and place the call in it. The call
+# actually does nothing except allow openzwave to be built.
+def build_dll_main(openzwave):
+    dll_main_path = openzwave + '\\cpp\\dllmain.cpp'
+    with open(dll_main_path, 'w') as f:
+        f.write(DLL_MAIN)
+
+
+# if you did decice to have distutils handle the building of openzwave you
+# will need to generate a list of the source files this the function to do that
+# you pass it the location of the source files and also a list of
+# directories/files that you want to ignore (ie: for windows we want to
+# ignore the linux and mac folders
+def get_sources(src_path, ignore):
+    found = []
+    for src_f in os.listdir(src_path):
+        src = os.path.join(src_path, src_f)
+        if os.path.isdir(src):
+            if src_f.lower() in ignore:
+                continue
+
+            found += get_sources(src, ignore)
+        elif src_f.endswith('.c') or src_f.endswith('.cpp'):
+            found += [src]
+    return found
+
+
+# This is a much cleaner version of the download openzwave. it does not write
+# anything to the disk except the extracted zip contents. There is no
+# "temporary" zip file written first.
+def get_openzwave(opzw_dir):
+    url = 'https://codeload.github.com/OpenZWave/open-zwave/zip/master'
+
+    print(
+        "fetching {0} into "
+        "{1} for version {2}".format(url, opzw_dir, pyozw_version)
+    )
+
+    import io
+    import zipfile
+
+    try:
+        from urllib2 import urlopen  # py2
+    except ImportError:
+        from urllib.request import urlopen  # py3
+
+    response = urlopen(url)
+    dst_file = io.BytesIO(response.read())
+
+    dst_file.seek(0)
+    zip_ref = zipfile.ZipFile(dst_file, 'r')
+    dst = os.path.split(opzw_dir)[0]
+    zip_ref.extractall(dst)
+    zip_ref.close()
+    dst_file.close()
+
+    dst = os.path.join(dst, zip_ref.namelist()[0])
+
+    if dst != opzw_dir:
+        os.rename(dst, opzw_dir)
+
+
+class Extension(distutils.core.Extension):
+    # right now you use a dictionary in which you add the various information
+    # to. and this is very hard to follow. in the end you then pass the
+    # dictionary to the parent class of this class. You can trim down on the
+    # hard to follow dictionary use and simply place the code that pertains
+    # to a specific OS into a subclass of this class and just pass an instance
+    # of that class directly to setup() this works pretty much the same as
+    # the Library class. you would add a subclass of this class and a subclass
+    # of the Library class to a file that is specific to that OS.
+
+    def __init__(
+        self,
+        openzwave,
+        flavor,
+        static,
+        backend,
+        extra_objects,
+        sources,
+        include_dirs,
+        define_macros,
+        libraries,
+        extra_compile_args
+    ):
+
+        # if you look at the contents of the method you will see that it
+        # sets all of the various build settings that are common to all of
+        # the OS's it also handles the backend type being cpp or cython. I
+        # know there was code added for pybind i have not been able to
+        # locate where it is actually used.
+        name = 'libopenzwave'
+        language = 'c++'
+
+        define_macros += [
+            ('PY_LIB_VERSION', pyozw_version.pyozw_version),
+            ('PY_LIB_FLAVOR', flavor),
+            ('PY_LIB_BACKEND', backend),
+            ('CYTHON_FAST_PYCCALL', 1),
+            ('_MT', 1),
+            ('_DLL', 1)
+        ]
+
+        if backend == 'cython':
+            define_macros += [('PY_SSIZE_T_CLEAN', 1)]
+            sources += ["src-lib/libopenzwave/libopenzwave.pyx"]
+
+        elif backend == 'cpp':
+            define_macros += [('PY_SSIZE_T_CLEAN', 1)]
+            sources += [
+                "openzwave-embed/open-zwave-master/"
+                "python-openzwave/src-lib/libopenzwave/libopenzwave.cpp"
+            ]
+            include_dirs += ["src-lib/libopenzwave"]
+
+        cpp_path = os.path.join(openzwave, 'cpp')
+        src_path = os.path.join(cpp_path, 'src')
+
+        if static:
+            include_dirs += [
+                src_path,
+                os.path.join(src_path, 'value_classes'),
+                os.path.join(src_path, 'platform')
+            ]
+
+        distutils.core.Extension.__init__(
+            self,
+            name=name,
+            language=language,
+            extra_objects=extra_objects,
+            sources=sources,
+            include_dirs=include_dirs,
+            define_macros=define_macros,
+            libraries=libraries,
+            extra_compile_args=extra_compile_args
+        )
+
+
+class Library(object):
+
+    def __init__(
+        self,
+        openzwave,
+        sources=[],
+        define_macros=[],
+        libraries=[],
+        library_dirs=[],
+        include_dirs=[],
+        extra_compile_args=[],
+        extra_link_args=[]
+    ):
+        self.openzwave = openzwave
+        self.name = 'OpenZwave'
+        self.sources = sources
+        self.define_macros = define_macros
+        self.libraries = libraries
+        self.library_dirs = library_dirs
+        self.include_dirs = include_dirs
+        self.extra_compile_args = extra_compile_args
+        self.extra_link_args = extra_link_args
+
+    def clean_openzwave(self):
+        distutils.command.build_clib.log.info(
+            'Removing {0}'.format(self.openzwave)
+        )
+        try:
+            shutil.rmtree(self.openzwave)
+            distutils.command.build_clib.log.info(
+                'Successfully removed {0}'.format(self.openzwave)
+            )
+        except OSError:
+            distutils.command.build_clib.log.error(
+                'Failed to remove {0}'.format(self.openzwave)
+            )
+        return True
+
+    def clean_cython(self):
+        try:
+            os.remove('src-lib/libopenzwave/libopenzwave.cpp')
+        except Exception:
+            pass
+
+    @property
+    def so_path(self):
+        import pyozw_pkgconfig
+        ldpath = pyozw_pkgconfig.libs_only_l('libopenzwave')[2:]
+
+        distutils.command.build_clib.log.info(
+            "Running ldconfig on {0}... be patient ...".format(ldpath)
+        )
+
+        return ldpath
+
+    # these next 3 methods you would override accordingly. If you check in
+    # pyozw_win you will see the use of these methods
+    def clean(self, command_class):
+        distutils.command.build_clib.log.info(
+            "Clean OpenZwave in {0} ... be patient ...".format(
+                self.openzwave
+            )
+        )
+
+    def build(self, _):
+        raise NotImplementedError
+
+    def install(self, _):
+        raise NotImplementedError
+
+
+class build_clib(distutils.command.build_clib.build_clib):
+    # I have created this class in a manner that will allow it to be used
+    # commonly between the different OS's if you look in pyozw_win you will
+    # find a subclass of this class. It will show how to setup the build
+    # process for the other OS's. You can if you want to have distutils
+    # handle all of the building of openzwave as i did for Windows. You will
+    # need to set all of the proper compiler arguments. If you do not want to
+    # do that then all you would need to do is call spawn with the proper
+    # "make" to build it. either way this is a more streamlined mechanism.
+    # it also allows you to easily maintain the code because the code for a
+    # specific OS is all grouped together.
+
+    def build_libraries(self, libraries):
+        self.compiler.spawn = self.spawn
+        self.compiler.mkpath = self.mkpath
+
+        for lib in self.original_libraries:
+            if self.build_type == 'install':
+                distutils.command.build_clib.log.info(
+                    "Install OpenZwave... be patient ..."
+                )
+                lib.install(self)
+                distutils.command.build_clib.log.info(
+                    "OpenZwave installed and loaded."
+                )
+            else:
+                distutils.command.build_clib.log.info(
+                    "building '{0}' library".format(lib.name)
+                )
+                lib.build(self)
+
+    # we override this method because the original method only known how to
+    # process a dict for the library information. I opted to use a class as
+    # this is far easier to deal with when adding or changing any of the values
+    # so here we create the dict from the class that is wanted by build_clib.
+    def finalize_options(self):
+        libraries = self.distribution.libraries
+        self.original_libraries = libraries
+        self.build_type = sys.argv[0].lower()
+        converted_libraries = []
+
+        for lib in libraries:
+            build_info = dict(
+                sources=lib.sources,
+                macros=lib.define_macros,
+                include_dirs=lib.include_dirs,
+            )
+
+            converted_libraries += [(lib.name, build_info)]
+
+        self.distribution.libraries = converted_libraries
+
+        distutils.command.build_clib.build_clib.finalize_options(self)
+
+    # we override the compilers mkpath so we can inject the verbose option.
+    # the compilers version does not allow for setting of a verbose level
+    # and distutils.dir_util.mkpath defaults to a verbose level of 1 which
+    # which prints out each and every directory it makes. This congests the
+    # output unnecessarily.
+    def mkpath(self, name, mode=0777):
+        distutils.dir_util.mkpath(
+            name,
+            mode,
+            dry_run=self.compiler.dry_run,
+            verbose=0
+        )
+
+    # this is the workhorse of the build process. it is a mechanism i use to
+    # buffer the output from subprocess.Popen and allows me to grab one line
+    # at a time as it becomes available. This eliminates any jumping or long
+    # pauses in information being written to the screen. This is far simpler
+    # then creating additional threads and using queue to pass information off
+    # to another thread to print the output. there is also no stalling the
+    # thread to wait for output.
+    @staticmethod
+    def spawn(cmd, search_path=1, level=1, cwd=None):
+        if sys.version_info[0] > 2:
+            dummy_return = b''
+            line_endings = [b'.cpp', b'.c']
+        else:
+            dummy_return = ''
+            line_endings = ['.cpp', '.c']
+
+        if cwd is None:
+
+            p = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+        else:
+            p = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=cwd
+            )
+
+        while p.poll() is None:
+            with print_lock:
+                for line in iter(p.stdout.readline, dummy_return):
+                    line = line.strip()
+                    if line:
+                        if sys.platform.startswith('win'):
+                            for ending in line_endings:
+                                if line.endswith(ending):
+                                    if sys.version_info[0] > 2:
+                                        line = b'compiling ' + line + b'...'
+                                    else:
+                                        line = 'compiling ' + line + '...'
+                                    break
+                        if sys.version_info[0] > 2:
+                            sys.stdout.write(line.decode('utf-8') + '\n')
+                        else:
+                            sys.stdout.write(line + '\n')
+
+                for line in iter(p.stderr.readline, dummy_return):
+                    line = line.strip()
+                    if line:
+                        if sys.version_info[0] > 2:
+                            sys.stderr.write(line.decode('utf-8') + '\n')
+                        else:
+                            sys.stderr.write(line + '\n')
+
+        if not p.stdout.closed:
+            p.stdout.close()
+
+        if not p.stderr.closed:
+            p.stderr.close()
+

--- a/pyozw_common.py
+++ b/pyozw_common.py
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with python-openzwave. If not, see http://www.gnu.org/licenses.
 """
+
 from __future__ import print_function
 import os
 import sys
@@ -69,7 +70,7 @@ def build_dll_main(openzwave):
         f.write(DLL_MAIN)
 
 
-# if you did decice to have distutils handle the building of openzwave you
+# if you did device to have distutils handle the building of openzwave you
 # will need to generate a list of the source files this the function to do that
 # you pass it the location of the source files and also a list of
 # directories/files that you want to ignore (ie: for windows we want to
@@ -386,6 +387,8 @@ class build_clib(distutils.command.build_clib.build_clib):
                         else:
                             sys.stdout.write(line + '\n')
 
+                        sys.stdout.flush()
+
                 for line in iter(p.stderr.readline, dummy_return):
                     line = line.strip()
                     if line:
@@ -394,9 +397,13 @@ class build_clib(distutils.command.build_clib.build_clib):
                         else:
                             sys.stderr.write(line + '\n')
 
+                        sys.stderr.flush()
+
         if not p.stdout.closed:
             p.stdout.close()
 
         if not p.stderr.closed:
             p.stderr.close()
 
+        sys.stdout.flush()
+        sys.stderr.flush()

--- a/pyozw_msvc.py
+++ b/pyozw_msvc.py
@@ -1,0 +1,1706 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of **python-openzwave**
+project https://github.com/OpenZWave/python-openzwave.
+    :platform: Unix, Windows, MacOS X
+    :sinopsis: openzwave API
+.. moduleauthor: bibi21000 aka Sébastien GALLET <bibi21000@gmail.com>
+License : GPL(v3)
+**python-openzwave** is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+**python-openzwave** is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with python-openzwave. If not, see http://www.gnu.org/licenses.
+
+pyozw_msvc
+
+This tool is used to create an identical build environment to what is created
+when building a Visual Studio project or using any of the vcvars and vsvars
+batch files. There is a similar tool included with SetupTools and it is called
+msvc. The setup tools version is not complete and it is also error prone. It
+does not make an identical build environment.
+"""
+
+
+from __future__ import print_function
+import os
+import sys
+import ctypes
+
+from ctypes.wintypes import (
+    BOOL,
+    DWORD,
+    LPCVOID,
+    LPCWSTR,
+    LPVOID,
+    UINT,
+    INT
+)
+
+try:
+    _winreg = __import__('winreg')
+except ImportError:
+    _winreg = __import__('_winreg')
+
+
+POINTER = ctypes.POINTER
+CHAR = INT
+PUINT = POINTER(UINT)
+LPDWORD = POINTER(DWORD)
+
+
+_version = ctypes.windll.version
+
+_GetFileVersionInfoSize = _version.GetFileVersionInfoSizeW
+_GetFileVersionInfoSize.restype = DWORD
+_GetFileVersionInfoSize.argtypes = [LPCWSTR, LPDWORD]
+
+_GetFileVersionInfo = _version.GetFileVersionInfoW
+_GetFileVersionInfo.restype = BOOL
+_GetFileVersionInfo.argtypes = [LPCWSTR, DWORD, DWORD, LPVOID]
+
+_VerQueryValue = _version.VerQueryValueW
+_VerQueryValue.restype = BOOL
+_VerQueryValue.argtypes = [LPCVOID, LPCWSTR, POINTER(LPVOID), PUINT]
+
+
+# noinspection PyPep8Naming
+class VS_FIXEDFILEINFO(ctypes.Structure):
+    _fields_ = [
+        ("dwSignature", DWORD),  # will be 0xFEEF04BD
+        ("dwStrucVersion", DWORD),
+        ("dwFileVersionMS", DWORD),
+        ("dwFileVersionLS", DWORD),
+        ("dwProductVersionMS", DWORD),
+        ("dwProductVersionLS", DWORD),
+        ("dwFileFlagsMask", DWORD),
+        ("dwFileFlags", DWORD),
+        ("dwFileOS", DWORD),
+        ("dwFileType", DWORD),
+        ("dwFileSubtype", DWORD),
+        ("dwFileDateMS", DWORD),
+        ("dwFileDateLS", DWORD)
+    ]
+
+
+def _get_file_version(filename):
+    dw_len = _GetFileVersionInfoSize(filename, None)
+    if not dw_len:
+        raise ctypes.WinError()
+
+    lp_data = (CHAR * dw_len)()
+    if not _GetFileVersionInfo(filename, 0, ctypes.sizeof(lp_data), lp_data):
+        raise ctypes.WinError()
+
+    u_len = UINT()
+    lpffi = POINTER(VS_FIXEDFILEINFO)()
+    lplp_buffer = ctypes.cast(ctypes.pointer(lpffi), POINTER(LPVOID))
+    if not _VerQueryValue(lp_data, "\\", lplp_buffer, ctypes.byref(u_len)):
+        raise ctypes.WinError()
+
+    ffi = lpffi.contents
+    return (
+        ffi.dwFileVersionMS >> 16,
+        ffi.dwFileVersionMS & 0xFFFF,
+        ffi.dwFileVersionLS >> 16,
+        ffi.dwFileVersionLS & 0xFFFF,
+    )
+
+
+def _get_reg_value(path, key):
+    d = _read_reg_values(path)
+    if key in d:
+        return d[key]
+
+    return ''
+
+
+def _read_reg_keys(key):
+    if isinstance(key, tuple):
+        root = key[0]
+        key = key[1]
+    else:
+        root = _winreg.HKEY_LOCAL_MACHINE
+        key = 'SOFTWARE\\Wow6432Node\\Microsoft\\' + key
+
+    try:
+        handle = _winreg.OpenKeyEx(root, key)
+    except _winreg.error:
+        return []
+    res = []
+
+    for i in range(_winreg.QueryInfoKey(handle)[0]):
+        res += [_winreg.EnumKey(handle, i)]
+
+    return res
+
+
+def _read_reg_values(key):
+    if isinstance(key, tuple):
+        root = key[0]
+        key = key[1]
+    else:
+        root = _winreg.HKEY_LOCAL_MACHINE
+        key = 'SOFTWARE\\Wow6432Node\\Microsoft\\' + key
+
+    try:
+        handle = _winreg.OpenKeyEx(root, key)
+    except _winreg.error:
+        return {}
+    res = {}
+    for i in range(_winreg.QueryInfoKey(handle)[1]):
+        name, value, _ = _winreg.EnumValue(handle, i)
+        res[_convert_mbcs(name)] = _convert_mbcs(value)
+
+    return res
+
+
+def _convert_mbcs(s):
+    dec = getattr(s, "decode", None)
+    if dec is not None:
+        try:
+            s = dec("mbcs")
+        except UnicodeError:
+            pass
+    return s
+
+# I have separated the environment into several classes
+# Environment - the main environment class.
+# the environment class is what is going to get used. this handles all of the
+# non specific bits of the environment. all of the rest of the classes are
+# brought together in the environment to form a complete build environment.
+
+# NETInfo - Any .NET related environment settings
+
+# WindowsSDKInfo - Any Windows SDK environment settings
+
+# VisualStudioInfo - Any VisualStudios environment settings (if applicable)
+
+# VisualCInfo - Any VisualC environment settings
+
+# PythonInfo - This class really isnt for environment settings as such.
+# It is more of a convenience class. it will get things like a list of the
+# includes specific to the python build. the architecture of the version of
+# python that is running stuff along those lines.
+
+
+class PythonInfo(object):
+
+    @property
+    def architecture(self):
+        return 'x64' if sys.maxsize > 2 ** 32 else 'x86'
+
+    @property
+    def version(self):
+        return '.'.join(str(ver) for ver in sys.version_info)
+
+    @property
+    def dependency(self):
+        return 'Python%d%d.lib' % sys.version_info[:2]
+
+    @property
+    def includes(self):
+        python_path = os.path.dirname(sys.executable)
+        python_include = os.path.join(python_path, 'include')
+
+        python_includes = [python_include]
+        for root, dirs, files in os.walk(python_include):
+            for d in dirs:
+                python_includes += [os.path.join(root, d)]
+        return python_includes
+
+    @property
+    def libraries(self):
+        python_path = os.path.dirname(sys.executable)
+        python_lib = os.path.join(python_path, 'libs')
+
+        python_libs = [python_lib]
+        for root, dirs, files in os.walk(python_lib):
+            for d in dirs:
+                python_libs += [os.path.join(root, d)]
+        return python_libs
+
+
+python_info = PythonInfo()
+
+
+class VisualCInfo(object):
+
+    def __init__(self, platform, strict_version, minimum_version):
+        self.platform = platform
+        self.strict_version = strict_version
+        self.minimum_version = minimum_version
+        self.__installed_versions = None
+
+    @property
+    def f_sharp_path(self):
+        f_sharp_path = _get_reg_value(
+            'Microsoft\\VisualStudio\\{0:.1f}\\Setup\\F#'.format(
+                self.version
+            ),
+            'ProductDir'
+        )
+        if f_sharp_path and os.path.exists(f_sharp_path):
+            return f_sharp_path
+
+    @property
+    def ide_install_directory(self):
+        directory = self.install_directory
+        ide_directory = os.path.abspath(os.path.join(directory, '..'))
+
+        ide_directory = os.path.join(ide_directory, 'Common7', 'IDE', 'VC')
+        if os.path.exists(ide_directory):
+            return ide_directory
+
+    @property
+    def install_directory(self):
+        """
+        Visual C path
+        :return: Visual C path
+        """
+        return self._installed_c_paths[self.version]['base']
+
+    @property
+    def _installed_c_paths(self):
+
+        if self.__installed_versions is None:
+            self.__installed_versions = {}
+
+            reg_path = (
+                _winreg.HKEY_CLASSES_ROOT,
+                'Local Settings\\Software\\Microsoft\\Windows\\Shell\\MuiCache'
+            )
+
+            paths = []
+
+            for key in _read_reg_values(reg_path):
+                if 'cl.exe' in key:
+                    value = _get_reg_value(reg_path, key)
+                    if 'C++ Compiler Driver' in value:
+                        paths += [key]
+
+            for path in paths:
+                if not os.path.exists(path):
+                    continue
+
+                if '\\VC\\bin' in path:
+                    version = path.split('\\VC\\bin')[0]
+                else:
+                    version = path.split('\\bin\\Host')[0]
+
+                version = os.path.split(version)[1]
+                version = version.replace(
+                    'Microsoft Visual Studio',
+                    ''
+                ).strip()
+                base_version = float(int(version.split('.')[0]))
+
+                base_path = path.split('\\VC\\')[0] + '\\VC'
+                if os.path.exists(os.path.join(base_path, 'include')):
+                    vc_root = base_path
+                else:
+                    vc_root = path.split('\\bin\\')[0]
+
+                self.__installed_versions[version] = dict(
+                    base=base_path,
+                    root=vc_root
+                )
+                self.__installed_versions[base_version] = dict(
+                    base=base_path,
+                    root=vc_root
+                )
+        return self.__installed_versions
+
+    @property
+    def version(self):
+        """
+        Visual C version
+
+        Sometimes when building extension in python the version of the compiler
+        that was used to compile Python has to also be used to compile an
+        extension. I have this system set so it will automatically pick the
+        most recent compiler installation. this can be overridden in 2 ways.
+        The first way being that the compiler version that built Python has to
+        be used. The second way is you can set a minimum compiler version to
+        use.
+
+        :return: found Visual C version
+        """
+
+        py_version = sys.version_info[:2]
+        if py_version in ((2, 6), (2, 7), (3, 0), (3, 1), (3, 2)):
+            min_visual_c_version = 9.0
+
+        elif py_version in ((3, 3), (3, 4)):
+            min_visual_c_version = 10.0
+
+        elif py_version in ((3, 5), (3, 6), (3, 7)):
+            min_visual_c_version = 14.0
+        else:
+            raise RuntimeError(
+                'This library does not support '
+                'python version %d.%d' % py_version
+            )
+
+        max_version = 0.0
+
+        if self.strict_version is not None:
+            if self.strict_version < min_visual_c_version:
+                raise RuntimeError(
+                    'The set minimum compiler version is lower then the '
+                    'required compiler version for Python'
+                )
+            if self.strict_version not in self._installed_c_paths:
+                raise RuntimeError(
+                    'No Compatible Visual C version found.'
+                )
+            return self.strict_version
+
+        elif self.minimum_version is not None:
+            for version in self._installed_c_paths:
+                if not isinstance(version, float):
+                    continue
+
+                if version >= self.minimum_version:
+                    max_version = max(max_version, version)
+
+        else:
+            for version in self._installed_c_paths:
+                if not isinstance(version, float):
+                    continue
+
+                if version >= min_visual_c_version:
+                    max_version = max(max_version, version)
+
+        if max_version == 0:
+            raise RuntimeError(
+                'No Compatible Visual C\\C++ version found.'
+            )
+
+        return max_version
+
+    @property
+    def tools_version(self):
+        return os.path.split(self.tools_install_directory)[1]
+
+    @property
+    def toolset_version(self):
+        """
+        The platform toolset gets written to the solution file. this instructs
+        the compiler to use the matching MSVCPxxx.dll file.
+        :return: one of the following
+            Visual C  Visual Studio  Returned Value
+            VC 15.0 - VS 2017:       v141
+            VC 14.0 - VS 2015:       v140
+            VC 12.0 - VS 2013:       v120
+            VC 11.0 - VS 2012:       v110
+            VC 10.0 - VS 2010:       v100
+            VC  9.0 - VS 2008:       v90
+
+        """
+        toolsets = {
+            15.0: 'v141',
+            14.0: 'v140',
+            12.0: 'v120',
+            11.0: 'v110',
+            10.0: 'v100',
+            9.0:  'v90'
+        }
+
+        return toolsets[self.version]
+
+    @property
+    def msvc_dll_version(self):
+        msvc_dll_path = self.msvc_dll_path
+        for f in os.listdir(msvc_dll_path):
+            if f.endswith('dll'):
+                version = _get_file_version(os.path.join(msvc_dll_path, f))
+                return '.'.join(str(ver) for ver in version)
+
+    @property
+    def msvc_dll_path(self):
+        x64 = self.platform == 'x64'
+        folder_names = (
+            'Microsoft.VC{0}.CRT'.format(self.toolset_version[1:]),
+        )
+        if self.toolset_version == 'v140':
+            folder_names += ('Microsoft.VC141.CRT',)
+
+        redist_path = self.tools_redist_directory
+
+        for root, dirs, files in os.walk(redist_path):
+            if 'onecore' not in root:
+                for folder_name in folder_names:
+                    if folder_name in dirs:
+                        if x64 and ('amd64' in root or 'x64' in root):
+                            return os.path.join(root, folder_name)
+                        elif (
+                            not x64 and
+                            'amd64' not in root
+                            and 'x64' not in root
+                        ):
+                            return os.path.join(root, folder_name)
+
+    @property
+    def tools_redist_directory(self):
+        tools_install_path = self.tools_install_directory
+        if 'MSVC' in tools_install_path:
+            redist_path = tools_install_path.replace('Tools', 'Redist')
+            if 'BuildTools' in tools_install_path:
+                redist_path = redist_path.replace('BuildRedist', 'BuildTools')
+        else:
+            redist_path = os.path.join(self.install_directory, 'Redist')
+
+        if not os.path.exists(redist_path):
+            redist_path = os.path.split(redist_path)[0]
+            max_ver = (0, 0, 0)
+            for f in os.listdir(redist_path):
+                if os.path.isdir(os.path.join(redist_path, f)):
+                    ver = tuple(int(ver) for ver in f.split('.'))
+                    if ver > max_ver:
+                        max_ver = ver
+            if max_ver != (0, 0, 0):
+                return os.path.join(
+                    redist_path,
+                    '.'.join(str(ver) for ver in max_ver)
+                )
+            else:
+                return ''
+
+        else:
+            return redist_path
+
+    @property
+    def tools_install_directory(self):
+        """
+        Visual C compiler tools path.
+        :return: Path to the compiler tools
+        """
+        vc_version = self.version
+        if vc_version >= 14.0:
+            vc_tools_path = self._installed_c_paths[vc_version]['root']
+        else:
+            vc_tools_path = self._installed_c_paths[vc_version]['base']
+
+        return vc_tools_path
+
+    @property
+    def msbuild_version(self):
+        """
+        MSBuild versions are specific to the Visual C version
+        :return: MSBuild version, 3.5, 4.0, 12, 14, 15
+        """
+        vc_version = self.version
+        if vc_version == 9.0:
+            return 3.5
+        if vc_version in (10.0, 11.0):
+            return 4.0
+        else:
+            return vc_version
+
+    @property
+    def msbuild_path(self):
+        program_files = os.environ.get(
+            'ProgramFiles(x86)',
+            'C:\\Program Files (x86)'
+        )
+
+        ms_build_path = os.path.join(
+            program_files,
+            'MSBuild',
+            '{0:.1f}'.format(self.version),
+            'bin'
+        )
+
+        if self.platform == 'x64':
+            if os.path.exists(os.path.join(ms_build_path, 'x64')):
+                ms_build_path = os.path.join(ms_build_path, 'x64')
+            else:
+                ms_build_path = os.path.join(ms_build_path, 'amd64')
+
+        elif os.path.exists(os.path.join(ms_build_path, 'x86')):
+            ms_build_path = os.path.join(ms_build_path, 'x86')
+
+        if os.path.exists(ms_build_path):
+            return ms_build_path
+
+    @property
+    def html_help_path(self):
+
+        html_help_path = _get_reg_value(
+            'Windows\\CurrentVersion\\App Paths\\hhw.exe',
+            'Path'
+        )
+        if html_help_path and os.path.exists(html_help_path):
+            return html_help_path
+
+    @property
+    def path(self):
+        tools_path = self._installed_c_paths[self.version]['root']
+        base_path = os.path.join(tools_path, 'bin')
+
+        path = []
+
+        f_sharp_path = self.f_sharp_path
+        msbuild_path = self.msbuild_path
+
+        if self.platform == 'x64':
+            perf_tools_path = os.path.join(
+                self.tools_install_directory,
+                'Team Tools',
+                'Performance Toolsx64'
+            )
+        else:
+            perf_tools_path = os.path.join(
+                self.tools_install_directory,
+                'Team Tools',
+                'Performance Tools'
+            )
+
+        if msbuild_path is not None:
+            path += [msbuild_path]
+
+        if os.path.exists(perf_tools_path):
+            path += [perf_tools_path]
+
+        if f_sharp_path is not None:
+            path += [f_sharp_path]
+
+        html_help_path = self.html_help_path
+        if html_help_path is not None:
+            path += [html_help_path]
+
+        bin_path = os.path.join(
+            base_path,
+            'Host' + self.platform,
+            self.platform
+        )
+
+        if not os.path.exists(bin_path):
+            if self.platform == 'x64':
+                bin_path = os.path.join(base_path, 'x64')
+
+                if not os.path.exists(bin_path):
+                    bin_path = os.path.join(base_path, 'amd64')
+
+            else:
+                bin_path = os.path.join(base_path, 'x86')
+                if not os.path.exists(bin_path):
+                    bin_path = base_path
+
+        if os.path.exists(bin_path):
+            path += [bin_path]
+
+        return path
+
+    @property
+    def atlmfc_lib_path(self):
+        atlmfc = os.path.join(self.atlmfc_path, 'lib')
+        if self.platform == 'x64':
+            atlmfc_path = os.path.join(atlmfc, 'x64')
+            if not os.path.exists(atlmfc_path):
+                atlmfc_path = os.path.join(atlmfc, 'amd64')
+        else:
+            atlmfc_path = os.path.join(atlmfc, 'x86')
+            if not os.path.exists(atlmfc_path):
+                atlmfc_path = atlmfc
+
+        if os.path.exists(atlmfc_path):
+            return atlmfc_path
+
+    @property
+    def lib(self):
+        tools_path = self._installed_c_paths[self.version]['root']
+        path = os.path.join(tools_path, 'lib')
+
+        if self.platform == 'x64':
+            lib_path = os.path.join(path, 'x64')
+            if not os.path.exists(lib_path):
+                lib_path = os.path.join(lib_path, 'amd64')
+
+        else:
+            lib_path = os.path.join(path, 'x86')
+
+            if not os.path.exists(lib_path):
+                lib_path = path
+
+        lib = []
+        if os.path.exists(lib_path):
+            lib += [lib_path]
+
+        atlmfc_path = self.atlmfc_lib_path
+        if atlmfc_path is not None:
+            lib += [atlmfc_path]
+
+        return lib
+
+    @property
+    def lib_path(self):
+        tools_path = self._installed_c_paths[self.version]['root']
+        path = os.path.join(tools_path, 'lib')
+
+        if self.platform == 'x64':
+            lib = os.path.join(path, 'x64')
+            if not os.path.exists(lib):
+                lib = os.path.join(path, 'amd64')
+        else:
+            lib = os.path.join(path, 'x86')
+            if not os.path.exists(lib):
+                lib = path
+
+        references_path = os.path.join(lib, 'store', 'references')
+
+        lib_path = []
+        if os.path.exists(lib):
+            lib_path += [lib]
+
+        atlmfc_path = self.atlmfc_lib_path
+
+        if atlmfc_path is not None:
+            lib_path += [atlmfc_path]
+
+        if os.path.exists(references_path):
+            lib_path += [references_path]
+
+        return lib_path
+
+    @property
+    def atlmfc_path(self):
+        tools_path = self._installed_c_paths[self.version]['root']
+        atlmfc_path = os.path.join(tools_path, 'ATLMFC')
+        return atlmfc_path
+
+    @property
+    def atlmfc_include_path(self):
+        atlmfc_path = os.path.join(self.atlmfc_path, 'include')
+        if os.path.exists(atlmfc_path):
+            return atlmfc_path
+
+    @property
+    def include(self):
+        tools_path = self._installed_c_paths[self.version]['root']
+        include_path = os.path.join(tools_path, 'include')
+        atlmfc_path = self.atlmfc_include_path
+
+        include = []
+        if os.path.exists(include_path):
+            include += [include_path]
+
+        if atlmfc_path is not None:
+            include += [atlmfc_path]
+        return include
+
+    def __iter__(self):
+        env = dict(
+            VCIDEInstallDir=self.ide_install_directory + '\\',
+            VCToolsVersion=self.tools_version,
+            VCToolsInstallDir=self.tools_install_directory + '\\',
+            VCINSTALLDIR=self.install_directory + '\\',
+            VCToolsRedistDir=self.tools_redist_directory,
+            Path=self.path,
+            LIB=self.lib,
+            Include=self.include,
+            LIBPATH=self.lib_path,
+            FSHARPINSTALLDIR=self.f_sharp_path
+        )
+
+        for key, value in env.items():
+            if value is not None and value:
+                if isinstance(value, list):
+                    value = os.pathsep.join(value)
+                yield key, str(value)
+
+
+class VisualStudioInfo(object):
+
+    def __init__(self, c_info):
+        self.c_info = c_info
+
+    @property
+    def install_directory(self):
+        return os.path.abspath(
+            os.path.join(self.c_info.install_directory, '..')
+        )
+
+    @property
+    def dev_env_directory(self):
+        return os.path.join(self.install_directory, 'Common7', 'IDE')
+
+    @property
+    def common_tools(self):
+        return os.path.join(self.install_directory, 'Common7', 'Tools')
+
+    @property
+    def path(self):
+
+        path = [self.dev_env_directory, self.common_tools]
+
+        collection_tools_dir = _get_reg_value(
+            'VisualStudio\\VSPerf',
+            'CollectionToolsDir'
+        )
+        if collection_tools_dir and os.path.exists(collection_tools_dir):
+            path += [collection_tools_dir]
+
+        vs_ide_path = self.dev_env_directory
+
+        test_window_path = os.path.join(
+            vs_ide_path,
+            'CommonExtensions',
+            'Microsoft',
+            'TestWindow'
+        )
+
+        vs_tdb_path = os.path.join(
+            vs_ide_path,
+            'VSTSDB',
+            'Deploy'
+        )
+
+        if os.path.exists(vs_tdb_path):
+            path += [vs_tdb_path]
+
+        if os.path.exists(test_window_path):
+            path += [test_window_path]
+
+        return path
+
+    @property
+    def version(self):
+        return self.c_info.version
+
+    def __iter__(self):
+        env = dict(
+            Path=self.path,
+            VSINSTALLDIR=self.install_directory + '\\',
+            DevEnvDir=self.dev_env_directory + '\\',
+            VisualStudioVersion=self.version
+        )
+
+        env['VS{0:.0f}0COMNTOOLS'.format(self.c_info.version)] = (
+            self.common_tools
+        )
+        for key, value in env.items():
+            if value is not None and value:
+                if isinstance(value, list):
+                    value = os.pathsep.join(value)
+                yield key, str(value)
+
+
+class WindowsSDKInfo(object):
+
+    def __init__(self, platform, vc_version):
+        self.platform = platform
+        self.vc_version = vc_version
+
+    @property
+    def extension_sdk_directory(self):
+        version = self.version
+        if version.startswith('10'):
+            version = '10.0'
+
+        sdk_path = _get_reg_value(
+            'Microsoft SDKs\\Windows\\v' + version,
+            'InstallationFolder'
+        )
+
+        if sdk_path:
+            sdk_path = sdk_path.replace(
+                'Windows Kits',
+                'Microsoft SDKs\\Windows Kits'
+            )
+            extension_path = os.path.join(sdk_path[:-1], 'ExtensionSDKs')
+            if os.path.exists(extension_path):
+
+                return extension_path
+
+    @property
+    def lib_version(self):
+        return self.sdk_version
+
+    @property
+    def ver_bin_path(self):
+        bin_path = self.bin_path[:-1]
+        ver_bin_path = os.path.join(bin_path, self.version)
+        if os.path.exists(ver_bin_path):
+            return ver_bin_path
+        else:
+            return bin_path
+
+    @property
+    def mssdk(self):
+        return self.directory
+
+    @property
+    def ucrt_version(self):
+        return self.sdk_version[:-1]
+
+    @property
+    def ucrt_sdk_directory(self):
+        return self.directory + '\\'
+
+    @property
+    def bin_path(self):
+        bin_path = os.path.join(
+            self.directory,
+            'bin'
+        )
+
+        return bin_path + '\\'
+
+    @property
+    def lib(self):
+        directory = self.directory
+        version = self.version
+        lib = []
+
+        base_lib = os.path.join(
+            directory,
+            'lib',
+            version,
+        )
+        if not os.path.exists(base_lib):
+            base_lib = os.path.join(
+                directory,
+                'lib'
+            )
+
+        if os.path.exists(base_lib):
+
+            if self.platform == 'x64':
+                ucrt = os.path.join(base_lib, 'ucrt', self.platform)
+                um = os.path.join(base_lib, 'um', self.platform)
+                if not os.path.exists(ucrt):
+                    ucrt = os.path.join(base_lib, 'ucrt', 'amd64')
+
+                if not os.path.exists(um):
+                    um = os.path.join(base_lib, 'um', 'amd64')
+
+            else:
+                ucrt = os.path.join(base_lib, 'ucrt', self.platform)
+                um = os.path.join(base_lib, 'um', self.platform)
+
+                if not os.path.exists(ucrt):
+                    ucrt = os.path.join(base_lib, 'ucrt')
+
+                if not os.path.exists(um):
+                    um = os.path.join(base_lib, 'um')
+
+            if os.path.exists(ucrt):
+                lib += [ucrt]
+
+            if os.path.exists(um):
+                lib += [um]
+        return lib
+
+    @property
+    def path(self):
+        path = []
+        ver_bin_path = self.ver_bin_path
+
+        if self.platform == 'x64':
+            bin_path = os.path.join(ver_bin_path, 'x64')
+            if not os.path.exists(bin_path):
+                bin_path = os.path.join(ver_bin_path, 'amd64')
+        else:
+            bin_path = os.path.join(ver_bin_path, 'x86')
+
+            if not os.path.exists(bin_path):
+                bin_path = ver_bin_path
+
+        if os.path.exists(bin_path):
+            path += [bin_path]
+
+        type_script_path = self.type_script_path
+        if type_script_path is not None:
+            path += [type_script_path]
+
+        return path
+
+    @property
+    def type_script_path(self):
+        program_files = os.environ.get(
+            'ProgramFiles(x86)',
+            'C:\\Program Files (x86)'
+        )
+        type_script_path = os.path.join(
+            program_files,
+            'Microsoft SDKs',
+            'TypeScript'
+        )
+
+        if os.path.exists(type_script_path):
+            max_ver = 0.0
+            for version in os.listdir(type_script_path):
+                try:
+                    version = float(version)
+                except TypeError:
+                    continue
+                max_ver = max(max_ver, version)
+
+            type_script_path = os.path.join(type_script_path, str(max_ver))
+
+            if os.path.exists(type_script_path):
+                return type_script_path
+
+    @property
+    def include(self):
+        include_path = os.path.join(self.directory, 'include', self.version)
+        if not os.path.exists(include_path):
+            include_path = os.path.split(include_path)[0]
+
+        includes = []
+
+        for path in ('ucrt', 'cppwinrt', 'shared', 'um', 'winrt'):
+            pth = os.path.join(include_path, path)
+            if os.path.exists(pth):
+                includes += [pth]
+
+        gl_include = os.path.join(include_path, 'gl')
+
+        if os.path.exists(gl_include):
+            includes += [gl_include]
+
+        return includes
+
+    @property
+    def lib_path(self):
+        return self.sdk_lib_path
+
+    @property
+    def sdk_lib_path(self):
+        directory = self.directory
+        version = self.version
+
+        union_meta_data = os.path.join(
+            directory,
+            'UnionMetadata',
+            version
+        )
+        references = os.path.join(
+            directory,
+            'References',
+            version
+        )
+
+        lib_path = []
+
+        if os.path.exists(union_meta_data):
+            lib_path += [union_meta_data]
+
+        if os.path.exists(references):
+            lib_path += [references]
+
+        return lib_path
+
+    @property
+    def windows_sdks(self):
+        """
+        Windows SDK versions that are compatible with Visual C
+        :return: compatible Windows SDK versions
+        """
+        ver = self.vc_version
+        if ver <= 9.0:
+            return '7.0', '6.1', '6.0a'
+        elif ver == 10.0:
+            return '7.1', '7.0a'
+        elif ver == 11.0:
+            return '8.0', '8.0a'
+        elif ver == 12.0:
+            return '8.1', '8.1a'
+        elif ver >= 14.0:
+            return '10.0', '8.1'
+
+    @property
+    def version(self):
+        """
+        This is used in the solution file to tell the compiler what SDK to use.
+        We obtain a list of compatible Windows SDK versions for the
+        Visual C version. We check and see if any  of the compatible SDK's are
+        installed and if so we return that version.
+
+        :return: Installed Windows SDK version
+        """
+        for sdk in self.windows_sdks:
+            sdk_version = _get_reg_value(
+                'Microsoft SDKs\\Windows\\v' + sdk,
+                'ProductVersion'
+            )
+            if sdk == '10.0':
+                return sdk_version + '.0'
+            else:
+                return sdk
+
+        raise RuntimeError(
+            'Unable to locate suitable SDK %s' % (self.windows_sdks,)
+        )
+
+    @property
+    def sdk_version(self):
+        """
+        This is almost identical to target_platform. Except it returns the
+        actual version of the Windows SDK not the truncated version.
+
+        :return: actual Windows SDK version
+        """
+        for sdk in self.windows_sdks:
+            sdk_version = _get_reg_value(
+                'Microsoft SDKs\\Windows\\v' + sdk,
+                'ProductVersion'
+            )
+            return sdk_version + '.0' + '\\'
+
+        raise RuntimeError(
+            'Unable to locate suitable SDK %s' % (self.windows_sdks,)
+        )
+
+    @property
+    def directory(self):
+        """
+        Path to the Windows SDK version that has been found.
+        :return: Windows SDK path
+        """
+        for sdk in self.windows_sdks:
+            sdk_installation_folder = _get_reg_value(
+                'Microsoft SDKs\\Windows\\v' + sdk,
+                'InstallationFolder'
+            )
+            if sdk_installation_folder:
+                return sdk_installation_folder[:-1]
+        raise RuntimeError(
+            'Unable to locate suitable SDK %s' % (self.windows_sdks,)
+        )
+
+    def __iter__(self):
+        env = dict(
+            LIB=self.lib,
+            Path=self.path,
+            LIBPATH=self.lib_path,
+            Include=self.include,
+            UniversalCRTSdkDir=self.ucrt_sdk_directory,
+            ExtensionSdkDir=self.extension_sdk_directory,
+            WindowsSdkVerBinPath=self.ver_bin_path + '\\',
+            UCRTVersion=self.ucrt_version,
+            WindowsSDKLibVersion=self.lib_version,
+            WindowsSDKVersion=self.sdk_version,
+            WindowsSdkDir=self.directory + '\\',
+            WindowsLibPath=self.lib_path,
+            WindowsSdkBinPath=self.bin_path,
+            DISTUTILS_USE_SDK=1,
+            MSSDK=self.directory
+        )
+
+        for key, value in env.items():
+            if value is not None and value:
+                if isinstance(value, list):
+                    value = os.pathsep.join(value)
+                yield key, str(value)
+
+
+class NETInfo(object):
+
+    def __init__(self, platform, vc_version, sdk_version):
+        self.platform = platform
+        self.vc_version = vc_version
+        self.sdk_version = sdk_version
+
+    @property
+    def version(self):
+        """
+        .NET Version
+        :return: returns the version associated with the architecture
+        """
+        if self.platform == 'x64':
+            return self.version_64
+        else:
+            return self.version_32
+
+    @property
+    def version_32(self):
+        """
+        .NET 32bit framework version
+        :return: x86 .NET framework version
+        """
+
+        target_frameworks = {
+            15.0: ('4.7*', '4.6*', '4.5*', '4.0*', '3.5*', '3.0*', '2.0*'),
+            14.0: ('4.6*', '4.5*', '4.0*', '3.5*', '3.0*', '2.0*'),
+            12.0: ('4.5*', '4.0*', '3.5*', '3.0*', '2.0*'),
+            11.0: ('4.5*', '4.0*', '3.5*', '3.0*', '2.0*'),
+            10.0: ('4.0*', '3.5*', '3.0*', '2.0*'),
+            9.0:  ('3.5*', '3.0*', '2.0*')
+        }
+
+        target_framework = _get_reg_value(
+            'VisualStudio\\SxS\\VC7',
+            'FrameworkVer32'
+        )
+
+        if not target_framework:
+            import fnmatch
+
+            versions = list(
+                key for key in _read_reg_keys('.NETFramework\\')
+                if key.startswith('v')
+            )
+
+            target_frameworks = target_frameworks[self.vc_version]
+            for version in versions:
+                for target_framework in target_frameworks:
+                    if fnmatch.fnmatch(version, 'v' + target_framework):
+                        target_framework = version
+                        break
+                else:
+                    continue
+
+                break
+            else:
+                raise RuntimeError(
+                    'No Suitable .NET Framework found %s' %
+                    (target_frameworks,)
+                )
+        return target_framework
+
+    @property
+    def version_64(self):
+        """
+        .NET 64bit framework version
+        :return: x64 .NET framework version
+        """
+        target_framework = _get_reg_value(
+            'VisualStudio\\SxS\\VC7',
+            'FrameworkVer64'
+        )
+        if not target_framework:
+            target_framework = self.version_32
+
+        return target_framework
+
+    @property
+    def directory(self):
+        if self.platform == 'x64':
+            framework_path = os.path.join(
+                self.directory_64,
+                self.version_64
+            )
+        else:
+            framework_path = os.path.join(
+                self.directory_32,
+                self.version_32
+            )
+
+        return framework_path
+
+    @property
+    def directory_32(self):
+        """
+        .NET 32bit path
+        :return: path to x86 .NET
+        """
+        directory = _get_reg_value(
+            'VisualStudio\\SxS\\VC7\\',
+            'FrameworkDir32'
+        )
+
+        if directory is None:
+            return os.path.join(
+                os.environ.get('WINDIR', r'C:\Windows'),
+                'Microsoft.NET',
+                'Framework'
+            )
+
+        return directory[:-1]
+
+    @property
+    def directory_64(self):
+        """
+        .NET 64bit path
+        :return: path to x64 .NET
+        """
+        guess_fw = os.path.join(
+            os.environ.get('WINDIR', r'C:\Windows'),
+            'Microsoft.NET',
+            'Framework64'
+        )
+
+        return (
+            _get_reg_value('VisualStudio\\SxS\\VC7\\', 'FrameworkDir64') or
+            guess_fw
+        )
+
+    @property
+    def preferred_bitness(self):
+        return '32' if self.platform == 'x86' else '64'
+
+    @property
+    def _net_fx_versions(self):
+        import fnmatch
+
+        framework = self.version[1:].split('.')[:2]
+        net_fx_key = (
+            'WinSDK-NetFx{framework}Tools-{platform}'
+        ).format(
+            framework=''.join(framework),
+            platform=self.platform
+        )
+        ver = self.vc_version
+
+        if ver in (9.0, 10.0, 11.0, 12.0):
+            key = 'Microsoft SDKs\\Windows\\v{0}\\{1}'.format(
+                self.sdk_version,
+                net_fx_key
+            )
+
+            if self.sdk_version in ('6.0A', '6.1'):
+                key = key.replace(net_fx_key, 'WinSDKNetFxTools')
+
+            keys = (key,)
+
+        elif ver in (14.0, 15.0):
+            keys = (
+
+                'Microsoft SDKs\\NETFXSDK\\4.6*\\' + net_fx_key,
+                'Microsoft SDKs\\Windows\\v8.1\\' + net_fx_key
+            )
+            if ver == 15.0:
+                keys = (
+                           'Microsoft SDKs\\NETFXSDK\\4.7*\\' + net_fx_key,
+                       ) + keys
+
+        else:
+            raise RuntimeError(
+                'This package does not support VC version ' + str(ver)
+            )
+
+        for key in keys:
+            if '*' in key:
+                for fx_ver in _read_reg_keys('Microsoft SDKs\\NETFXSDK'):
+                    fx_ver = 'Microsoft SDKs\\NETFXSDK\\{0}\\{1}'.format(
+                        fx_ver,
+                        net_fx_key
+                    )
+
+                    if fnmatch.fnmatch(fx_ver, key):
+                        yield fx_ver
+            else:
+                val = _get_reg_value(
+                    key + '\\',
+                    'InstallationFolder'
+                )
+                if val:
+                    yield key
+
+    @property
+    def netfx_sdk_directory(self):
+
+        for key in self._net_fx_versions:
+            net_fx_path = _get_reg_value(
+                key.rsplit('\\', 1)[0],
+                'KitsInstallationFolder'
+             )
+
+            if net_fx_path and os.path.exists(net_fx_path):
+                return net_fx_path
+
+    @property
+    def net_fx_tools_directory(self):
+        for key in self._net_fx_versions:
+            net_fx_path = _get_reg_value(key, 'InstallationFolder')
+
+            if net_fx_path and os.path.exists(net_fx_path):
+                return net_fx_path
+
+    @property
+    def add(self):
+        return '__DOTNET_ADD_{0}BIT'.format(self.preferred_bitness)
+
+    @property
+    def net_tools(self):
+        if self.vc_version <= 10.0:
+            include32 = True
+            include64 = self.platform == 'x64'
+        else:
+            include32 = self.platform == 'x86'
+            include64 = self.platform == 'x64'
+
+        tools = []
+        if include32:
+            tools += [
+                os.path.join(self.directory_32, self.version_32)
+            ]
+        if include64:
+            tools += [
+                os.path.join(self.directory_64, self.version_64)
+            ]
+
+        return tools
+
+    @property
+    def executable_path_x64(self):
+        tools_directory = self.net_fx_tools_directory
+        if 'NETFX' in tools_directory:
+            if 'x64' in tools_directory:
+                return tools_directory
+            else:
+                tools_directory = os.path.join(tools_directory, 'x64')
+                if os.path.exists(tools_directory):
+                    return tools_directory
+
+    @property
+    def executable_path_x86(self):
+        tools_directory = self.net_fx_tools_directory
+        if 'NETFX' in tools_directory:
+            if 'x64' in tools_directory:
+                return (
+                    os.path.split(os.path.split(tools_directory)[0])[0] + '\\'
+                )
+            else:
+                return tools_directory
+        return None
+
+    @property
+    def lib(self):
+        sdk_directory = self.netfx_sdk_directory
+        sdk_directory = os.path.join(sdk_directory, 'lib', 'um')
+
+        if self.platform == 'x64':
+            lib_dir = os.path.join(sdk_directory, 'x64')
+            if not os.path.exists(lib_dir):
+                lib_dir = os.path.join(sdk_directory, 'amd64')
+        else:
+            lib_dir = os.path.join(sdk_directory, 'x86')
+            if not os.path.exists(lib_dir):
+                lib_dir = sdk_directory
+
+        if os.path.exists(lib_dir):
+            return [lib_dir]
+
+        return []
+
+    @property
+    def path(self):
+        path = self.lib_path
+        net_fx_tools = self.net_fx_tools_directory
+        if net_fx_tools:
+            path += [net_fx_tools]
+
+        return path
+
+    @property
+    def lib_path(self):
+        directory = self.directory
+
+        if directory and os.path.exists(directory):
+            return [directory]
+
+        return []
+
+    @property
+    def include(self):
+        net_fx_tools = self.net_fx_tools_directory
+
+        if net_fx_tools:
+            net_fx_tools = os.path.join(
+                net_fx_tools,
+                'include',
+                'um'
+            )
+            if os.path.exists(net_fx_tools):
+                return [net_fx_tools]
+
+        return []
+
+    def __iter__(self):
+
+        env = dict(
+            WindowsSDK_ExecutablePath_x64=self.executable_path_x64,
+            WindowsSDK_ExecutablePath_x86=self.executable_path_x86,
+            LIB=self.lib,
+            Path=self.path,
+            LIBPATH=self.lib_path,
+            Include=self.include,
+            __DOTNET_PREFERRED_BITNESS=self.preferred_bitness,
+            FrameworkDir=self.directory + '\\',
+            FrameworkVersion=self.version,
+            NETFXSDKDir=self.netfx_sdk_directory,
+        )
+
+        env[self.add] = '1'
+        if self.platform == 'x64':
+            env['FrameworkDIR64'] = self.directory_64 + '\\'
+            env['FrameworkVersion64'] = self.version_64
+        else:
+            env['FrameworkDIR32'] = self.directory_32 + '\\'
+            env['FrameworkVersion32'] = self.version_32
+
+        framework = env['FrameworkVersion'][1:].split('.')[:2]
+        framework_version_key = (
+            'Framework{framework}Version'.format(framework=''.join(framework))
+        )
+        env[framework_version_key] = 'v' + '.'.join(framework)
+
+        for key, value in env.items():
+            if value is not None and value:
+                if isinstance(value, list):
+                    value = os.pathsep.join(value)
+                yield key, str(value)
+
+
+class Environment(object):
+
+    def __init__(
+        self,
+        strict_visual_c_version=None,
+        minimum_visual_c_version=None,
+    ):
+
+        self.visual_c = VisualCInfo(
+            self.platform,
+            strict_visual_c_version,
+            minimum_visual_c_version
+        )
+
+        self.visual_studio = VisualStudioInfo(
+            self.visual_c
+        )
+
+        self.windows_sdk = WindowsSDKInfo(
+            self.platform,
+            self.visual_c.version
+        )
+
+        self.dot_net = NETInfo(
+            self.platform,
+            self.visual_c.version,
+            self.windows_sdk.version
+        )
+
+        self.python = PythonInfo()
+
+    @property
+    def machine_architecture(self):
+        import platform
+        return 'x64' if '64' in platform.machine() else 'x86'
+
+    @property
+    def platform(self):
+        """
+        :return: x86 or x64
+        """
+        import platform
+
+        win_64 = self.machine_architecture == 'x64'
+        python_64 = platform.architecture()[0] == '64bit' and win_64
+
+        return 'x64' if python_64 else 'x86'
+
+    @property
+    def configuration(self):
+        """
+        Build configuration
+        :return: one of ReleaseDLL, DebugDLL
+        """
+
+        if os.path.splitext(sys.executable)[0].endswith('_d'):
+            config = 'Debug'
+        else:
+            config = 'Release'
+
+        return config
+
+    def __iter__(self):
+        for item in self.build_environment.items():
+            yield item
+
+    @property
+    def build_environment(self):
+        """
+        This would be the work horse. This is where all of the gathered
+        information is put into a single container and returned.
+        The information is then added to os.environ in order to allow the
+        build process to run properly.
+
+        List of environment variables generated:
+        PATH
+        LIBPATH
+        LIB
+        INCLUDE
+        Platform
+        FrameworkDir
+        FrameworkVersion
+        FrameworkDIR32
+        FrameworkVersion32
+        FrameworkDIR64
+        FrameworkVersion64
+        VCToolsRedistDir
+        VCINSTALLDIR
+        VCToolsInstallDir
+        VCToolsVersion
+        WindowsLibPath
+        WindowsSdkDir
+        WindowsSDKVersion
+        WindowsSdkBinPath
+        WindowsSdkVerBinPath
+        WindowsSDKLibVersion
+        __DOTNET_ADD_32BIT
+        __DOTNET_ADD_64BIT
+        __DOTNET_PREFERRED_BITNESS
+        Framework{framework version}Version
+        NETFXSDKDir
+        UniversalCRTSdkDir
+        UCRTVersion
+        ExtensionSdkDir
+
+        These last 2 are set to ensure that distuils uses these environment
+        variables when compiling libopenzwave.pyd
+        MSSDK
+        DISTUTILS_USE_SDK
+
+        :return: dict of environment variables
+        """
+        path = os.environ.get('Path', '')
+
+        env = dict(
+            __VSCMD_PREINIT_PATH=path,
+            Platform=self.platform,
+        )
+
+        def update_env(cls):
+            for key, value in cls:
+                if key in env:
+                    env[key] += ';' + value
+                else:
+                    env[key] = value
+
+        update_env(self.visual_c)
+        update_env(self.visual_studio)
+        update_env(self.windows_sdk)
+        update_env(self.dot_net)
+
+        env['Path'] += ';' + path
+
+        return env
+
+    def __str__(self):
+        template = (
+            'Machine architecture: {machine_architecture}\n'
+            'Build architecture: {architecture}\n'
+            '\n'
+            '== Windows SDK ================================================\n'
+            '   version:     {target_platform}\n'
+            '   sdk version: {windows_sdk_version}\n'
+            '   path:        {target_platform_path}\n'
+            '\n'
+            '   -- Universal CRT -------------------------------------------\n'
+            '      path: {ucrt_sdk_directory}\n'
+            '   -- ATLMFC --------------------------------------------------\n'
+            '      path:         {atlmfc_path}\n'
+            '      include path: {atlmfc_include_path}\n'
+            '      lib path:     {atlmfc_lib_path}\n'
+            '\n'
+            '== Extension SDK ==============================================\n'
+            '   path: {extension_sdk_directory}\n'
+            '\n'
+            '== TypeScript =================================================\n'
+            '   path: {type_script_path}\n'
+            '\n'
+            '== HTML Help ==================================================\n'
+            '   path: {html_help_path}\n'
+            '\n'
+            '== .NET =======================================================\n'
+            '   version:    {target_framework}\n'
+            '\n'
+            '   -- x86 -----------------------------------------------------\n'
+            '      version: {framework_version_32}\n'
+            '      path:    {framework_dir_32}\n'
+            '   -- x64 -----------------------------------------------------\n'
+            '      version: {framework_version_64}\n'
+            '      path:    {framework_dir_64}\n'
+            '   -- NETFX ---------------------------------------------------\n'
+            '      path:         {net_fx_tools_directory}\n'
+            '      x86 exe path: {executable_path_x86}\n'
+            '      x64 exe path: {executable_path_x64}\n'
+            '\n'
+            '== Visual C ===================================================\n'
+            '   version: {visual_c_version}\n'
+            '   path:    {visual_c_path}\n'
+            '\n'
+            '   -- Tools ---------------------------------------------------\n'
+            '      version:     {tools_version}\n'
+            '      path:        {tools_install_path}\n'
+            '      redist path: {vc_tools_redist_path}\n'
+            '   -- F# ------------------------------------------------------\n'
+            '      path: {f_sharp_path}\n'
+            '   -- DLL -----------------------------------------------------\n'
+            '      version: {platform_toolset}-{msvc_dll_version}\n'
+            '      path:    {msvc_dll_path}\n'
+            '\n'
+            '== MSBuild ====================================================\n'
+            '   version: {msbuild_version}\n'
+            '   path:    {msbuild_path}\n'
+            '\n'
+            '== Python =====================================================\n'
+            '  version: {py_version}\n'
+            '  architecture: {py_architecture}\n'
+            '  library: {py_dependency}\n'
+            '  libs: {py_libraries}\n'
+            '  includes: {py_includes}\n'
+            '\n'
+        )
+        return template.format(
+            machine_architecture=self.machine_architecture,
+            architecture=self.platform,
+            target_platform=self.windows_sdk.version,
+            windows_sdk_version=self.windows_sdk.sdk_version,
+            target_platform_path=self.windows_sdk.directory,
+            target_framework=self.dot_net.version,
+            framework_version_32=self.dot_net.version_32,
+            framework_dir_32=self.dot_net.directory_32,
+            framework_version_64=self.dot_net.version_64,
+            framework_dir_64=self.dot_net.directory_64,
+            visual_c_version=self.visual_c.version,
+            visual_c_path=self.visual_c.install_directory,
+            tools_version=self.visual_c.tools_version,
+            tools_install_path=self.visual_c.tools_install_directory,
+            vc_tools_redist_path=self.visual_c.tools_redist_directory,
+            platform_toolset=self.visual_c.toolset_version,
+            msvc_dll_version=self.visual_c.msvc_dll_version,
+            msvc_dll_path=self.visual_c.msvc_dll_path,
+            msbuild_version=self.visual_c.msbuild_version,
+            msbuild_path=self.visual_c.msbuild_path,
+            py_version=self.python.version,
+            py_architecture=self.python.architecture,
+            py_dependency=self.python.dependency,
+            py_libraries=self.python.libraries,
+            py_includes=self.python.includes,
+            f_sharp_path=self.visual_c.f_sharp_path,
+            html_help_path=self.visual_c.html_help_path,
+            atlmfc_lib_path=self.visual_c.atlmfc_lib_path,
+            atlmfc_include_path=self.visual_c.atlmfc_include_path,
+            atlmfc_path=self.visual_c.atlmfc_path,
+            extension_sdk_directory=self.windows_sdk.extension_sdk_directory,
+            ucrt_sdk_directory=self.windows_sdk.ucrt_sdk_directory,
+            type_script_path=self.windows_sdk.type_script_path,
+            net_fx_tools_directory=self.dot_net.net_fx_tools_directory,
+            executable_path_x64=self.dot_net.executable_path_x64,
+            executable_path_x86=self.dot_net.executable_path_x86,
+        )
+
+
+if __name__ == '__main__':
+    e = Environment()
+    print(e)
+    print('\n\n')
+    for k, v in e:
+        if os.pathsep in v:
+            print(k + ':')
+            for itm in v.split(os.pathsep):
+                print('   ', itm)
+        else:
+            print(k + ':', v)
+        print()

--- a/pyozw_win.py
+++ b/pyozw_win.py
@@ -1,802 +1,378 @@
 # -*- coding: utf-8 -*-
 """
-This file is part of **python-openzwave** project https://github.com/OpenZWave/python-openzwave.
+This file is part of **python-openzwave**
+project https://github.com/OpenZWave/python-openzwave.
     :platform: Unix, Windows, MacOS X
     :sinopsis: openzwave API
-
 .. moduleauthor: bibi21000 aka Sébastien GALLET <bibi21000@gmail.com>
-
 License : GPL(v3)
-
 **python-openzwave** is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-
 **python-openzwave** is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with python-openzwave. If not, see http://www.gnu.org/licenses.
-
 """
 
+from __future__ import print_function
 import sys
 import os
-import platform
 import shutil
-from pyozw_version import pyozw_version
+import threading
+import subprocess
+import pyozw_msvc
+import pyozw_common
+import pyozw_version
 
-try:
-    _winreg = __import__('_winreg')
-except ImportError:
-    _winreg = __import__('winreg')
+# this is some tailored code to detect an appveyor build. if it is
+# then the environment is set to only use a specific compiler version.
+if 'PYTHON_VERSION' in os.environ and 'PYTHON_ARCH' in os.environ:
+    python_version = os.environ['PYTHON_VERSION']
 
-
-from subprocess import Popen, PIPE
-
-# this is simply to show that you can build using only VS2017 as a requirement.
-VS2017_VCVARSALL = r'"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"'
-
-WIN64 = '64' in platform.machine()
-PYTHON64 = platform.architecture()[0] == '64bit' and WIN64
-ARCH = 'x64' if PYTHON64 else 'x86'
-
-
-try:
-    PY3 = not unicode
-except NameError:
-    PY3 = True
-
-TOOLSETS = {
-    15.0: ['v141', '15.0'],  # vs2017
-    14.0: ['v140', '14.0'],  # vs2015
-    10.0: ['v100', '4.0'],  # vs2010
-    4.0:  ['v90', '4.0'],  # vs2008
-}
+    if python_version == '3.6.x':
+        environment = pyozw_msvc.Environment(strict_visual_c_version=14.0)
+    elif python_version == '3.4.x':
+        environment = pyozw_msvc.Environment(strict_visual_c_version=10.0)
+    elif python_version == '2.7.x':
+        environment = pyozw_msvc.Environment(strict_visual_c_version=10.0)
+    else:
+        environment = pyozw_msvc.Environment(minimum_visual_c_version=10.0)
+else:
+    environment = pyozw_msvc.Environment(minimum_visual_c_version=10.0)
 
 
-def setup_build_env_2017():
-    proc = Popen(
-        VS2017_VCVARSALL + ' ' + ARCH + ' && set',
-        shell=True,
-        stdout=PIPE,
-        stderr=PIPE
-    )
-
-    test_env = {}
-    for line in proc.stdout:
-        if PY3:
-            line = line.decode("utf-8")
-
-        if '=' in line:
-            key, value = line.split('=', 1)
-            test_env[key.strip()] = value.strip()
-
-    for key, value in list(test_env.items()):
-        if str(os.environ.get(key, None)) != value:
-            os.environ[key] = value
-
-    os.environ['DISTUTILS_USE_SDK'] = '1'
+VERSION_COMMAND = 'GIT-VS-VERSION-GEN.bat --quiet . winversion.cpp'
 
 
-# comment this line to run normally.
-setup_build_env_2017()
+# When running a build on linux the makefile handles the creation of the
+# openzwave version file. if you build openzwave using visual studio the same
+# is done. Since we are letting distutils handle the compiling of openzwave
+# we need to create that version file ourselves.
+# that is what this function does.
 
+def build_version_file(openzwave):
+    version_file = openzwave + "\\cpp\\build\\windows\\winversion.cpp"
+    if os.path.exists(version_file):
+        os.remove(version_file)
 
-def _get_reg_value(path, key):
-    d = _read_reg_values(path)
-    if key in d:
-        return d[key]
-    return ''
-
-
-def _read_reg_keys(key):
     try:
-        handle = _winreg.OpenKeyEx(
-            _winreg.HKEY_LOCAL_MACHINE,
-            'SOFTWARE\\Wow6432Node\\Microsoft\\' + key
-        )
-    except _winreg.error:
-        return []
-    res = []
+        cwd = os.path.dirname(__file__)
+        if not cwd:
+            cwd = os.getcwd()
+    except WindowsError:
+        cwd = os.getcwd()
 
-    for i in range(_winreg.QueryInfoKey(handle)[0]):
-        res += [_winreg.EnumKey(handle, i)]
-
-    return res
-
-
-def _read_reg_values(key):
-    try:
-        handle = _winreg.OpenKeyEx(
-            _winreg.HKEY_LOCAL_MACHINE,
-            'SOFTWARE\\Wow6432Node\\Microsoft\\' + key
-        )
-    except _winreg.error:
-        return {}
-    res = {}
-    for i in range(_winreg.QueryInfoKey(handle)[1]):
-        name, value, _ = _winreg.EnumValue(handle, i)
-        res[_convert_mbcs(name)] = _convert_mbcs(value)
-
-    return res
+    cwd = os.path.abspath(cwd)
+    os.chdir(os.path.abspath(openzwave + '\\cpp\\build\\windows'))
+    p = subprocess.Popen(VERSION_COMMAND)
+    p.communicate()
+    os.chdir(cwd)
 
 
-def _convert_mbcs(s):
-    dec = getattr(s, "decode", None)
-    if dec is not None:
-        try:
-            s = dec("mbcs")
-        except UnicodeError:
-            pass
-    return s
-
-
-def get_environment():
-    from setuptools.msvc import (
-        msvc9_query_vcvarsall,
-        EnvironmentInfo,
-        msvc14_get_vc_env
-    )
-
-    py_version = sys.version_info[:2]
-
-    if py_version >= (3, 5):
-        env = msvc14_get_vc_env(ARCH)
-        msbuild_version = 14.0
-        env_info = EnvironmentInfo(ARCH)
-        msbuild_path = _find_file(
-            'MSBuild.exe',
-            env_info.MSBuild[0]
-        )[0]
-
-        sdks = ('10.0', '8.1', '8.1A', '8.0', '8.0A')
-        solution_dest = 'vs2015'
-
-    elif (3, 5) > py_version >= (3, 3):
-        env = msvc9_query_vcvarsall(10.0, ARCH)
-        msbuild_version = 4.0
-        msbuild_path = _get_reg_value(
-            'MSBuild\\4.0',
-            'MSBuildOverrideTasksPath'
-        )
-
-        if msbuild_path:
-            msbuild_path = _find_file(
-                'MSBuild.exe',
-                msbuild_path
-            )[0]
-
-        sdks = ('7.1', '7.0A')
-        solution_dest = 'vs2010'
-
-    elif (3, 3) > py_version >= (2, 6):
-        env = msvc9_query_vcvarsall(9.0, ARCH)
-        msbuild_version = 4.0
-        msbuild_path = _get_reg_value(
-            'MSBuild\\4.0',
-            'MSBuildOverrideTasksPath'
-        )
-
-        if msbuild_path:
-            msbuild_path = _find_file(
-                'MSBuild.exe',
-                msbuild_path
-            )[0]
-
-        sdks = ('6.1', '6.1A', '6.0A')
-        solution_dest = 'vs2008'
-
-    else:
-        raise RuntimeError(
-            'This library does not support python versions < 2.6'
-        )
-
-    for sdk in sdks:
-        sdk_version = _get_reg_value(
-            'Microsoft SDKs\\Windows\\v' + sdk,
-            'ProductVersion'
-        )
-        if sdk_version:
-            sdk_installation_folder = _get_reg_value(
-                'Microsoft SDKs\\Windows\\v' + sdk,
-                'InstallationFolder'
-            )
-            target_platform = sdk_version
-            os.environ['WindowsSdkDir'] = sdk_installation_folder
-            break
-    else:
-        raise RuntimeError('Unable to locate suitable SDK %s' % (sdks,))
-
-    platform_toolset, tools_version = TOOLSETS[msbuild_version]
-
-    return (
-        env,
-        msbuild_version,
-        msbuild_path,
-        sdk_installation_folder,
-        target_platform,
-        platform_toolset,
-        tools_version,
-        solution_dest
-    )
-
-
-def _find_file(file_name, path):
-    res = []
-
-    for root, dirs, files in os.walk(path):
-        if (
-            ((PYTHON64 and 'amd64' in root) or 'amd64' not in root) and
-            file_name in files
-        ):
-            res.append(os.path.join(root, file_name))
-    return res
-
-
-def setup_build_environment(openzwave, build_type):
-    if 'DISTUTILS_USE_SDK' in os.environ:
-        target_platform = os.environ['WINDOWSSDKVERSION'].replace('\\', '')
-
-        if 'VS150COMNTOOLS' in os.environ:
-            msbuild_version = 15.0
-            solution_dest = 'vs2017'
-
-        elif 'VS140COMNTOOLS' in os.environ:
-            msbuild_version = 14.0
-            solution_dest = 'vs2015'
-        else:
-            raise RuntimeError
-
-        msbuild_path = _find_file('MSBuild.exe', os.environ['VSINSTALLDIR'])[0]
-        platform_toolset, tools_version = TOOLSETS[msbuild_version]
-        sdk_installation_folder = os.environ['WINDOWSSDKVERBINPATH']
-        os.environ['MSSDK'] = sdk_installation_folder
-
-    else:
-        (
-            env,
-            msbuild_version,
-            msbuild_path,
-            sdk_installation_folder,
-            target_platform,
-            platform_toolset,
-            tools_version,
-            solution_dest
-        ) = get_environment()
-
-        if 'WINDOWSSDKVERBINPATH' in env:
-            sdk_installation_folder = env['WINDOWSSDKVERBINPATH']
-
-        env['MSSDK'] = sdk_installation_folder
-        env['DISTUTILS_USE_SDK'] = '1'
-
-        for key, value in env.items():
-            os.environ[key] = value
-
-        if 'VS150COMNTOOLS' in os.environ and msbuild_version == 14.0:
-            platform_toolset = 'v141'
-            tools_version = '15.0'
-            msbuild_version = 15.0
-            solution_dest = 'vs2017'
-
-        if 'WINDOWSSDKLIBVERSION' in os.environ:
-            target_platform = (
-                os.environ['WINDOWSSDKLIBVERSION'].replace('\\', '')
-            )
-
-    if not msbuild_path:
-        raise RuntimeError(
-            'Unable to locate MSBuild to compile OpenZWave'
-        )
-
-    project_base_path = os.path.abspath(
-        os.path.join(
-            openzwave,
-            'cpp',
-            'build',
-            'windows'
-        )
-    )
-
-    project_path = os.path.join(project_base_path, solution_dest)
-
-    if PYTHON64:
-        build_path = os.path.join(project_path, 'x64', build_type)
-    else:
-        build_path = os.path.join(project_path, build_type)
-
-    if not os.path.exists(project_path):
-        shutil.copytree(
-            os.path.join(project_base_path, 'vs2010'),
-            project_path
-        )
-
-    print('Updating VS solution please wait.')
-
-    if update_vs_project(
-        os.path.join(project_path, 'OpenZWave.vcxproj'),
-        tools_version,
-        platform_toolset,
-        target_platform
+class Extension(pyozw_common.Extension):
+    def __init__(
+        self,
+        openzwave,
+        flavor,
+        static,
+        backend
     ):
-        with open(os.path.join(project_path, 'OpenZWave.sln'), 'r') as f:
-            sln = str(f.read()).replace('\r', '')
+        for key, value in environment.build_environment.items():
+            os.environ[key] = value
 
-        if GLOBAL_SELECTION_TEMPLATE not in sln:
-            sln = sln.replace(
-                GLOBAL_SELECTION_KEY,
-                GLOBAL_SELECTION_TEMPLATE
+        extra_objects = []
+        define_macros = []
+        sources = []
+        include_dirs = ['src-lib\\libopenzwave']
+
+        libraries = []
+        extra_compile_args = [
+            # Enables function-level linking.
+            '/Gy',
+            # Creates fast code.
+            '/O2',
+            # Uses the __cdecl calling convention (x86 only).
+            '/Gd',
+            # Omits frame pointer (x86 only).
+            '/Oy',
+            # Generates intrinsic functions.
+            '/Oi',
+            # Forces writes to the program database (PDB) file to be
+            # serialized through MSPDBSRV.EXE.
+            '/FS',
+            # Specify floating-point behavior.
+            '/fp:precise',
+            # Specifies standard behavior
+            '/Zc:inline',
+            '/Zc:wchar_t',
+            # Specifies standard behavior
+            '/Zc:forScope',
+            # I cannot remember what this does. I do know it does get rid of
+            # a compiler warning
+            '/EHsc',
+            # compiler warnings to ignore
+            '/wd4996',
+            '/wd4244',
+            '/wd4005',
+        ]
+
+        if pyozw_common.DEBUG_BUILD:
+            define_macros += [('_DEBUG', 1)]
+            libraries += ["setupapi", "msvcrtd", "ws2_32", "dnsapi"]
+        else:
+            libraries += ["setupapi", "msvcrt", "ws2_32", "dnsapi"]
+
+        libraries += [environment.python.dependency.split('.')[0]]
+
+        cpp_path = os.path.join(openzwave, 'cpp')
+        src_path = os.path.join(cpp_path, 'src')
+        if static:
+            build_path = os.path.join(openzwave, 'build')
+
+            # this is a really goofy thing to have to do. But distutils will
+            # pitch a fit if we try to run the linker without a PyInit
+            # expression. it does absolutely nothing. Decoration I guess.
+
+            extra_objects += [
+                os.path.join(build_path + '\\lib_build', 'OpenZWave.lib')
+            ]
+
+            include_dirs += [
+                build_path,
+                os.path.join(cpp_path, 'build', 'windows'),
+
+            ]
+
+        else:
+            libraries += ["OpenZWave"]
+            extra_compile_args += [
+                src_path,
+                os.path.join(src_path, 'value_classes'),
+                os.path.join(src_path, 'platform'),
+            ]
+
+        pyozw_common.Extension.__init__(
+            self,
+            openzwave,
+            flavor,
+            static,
+            backend,
+            extra_objects=extra_objects,
+            sources=sources,
+            include_dirs=include_dirs,
+            define_macros=define_macros,
+            libraries=libraries,
+            extra_compile_args=extra_compile_args
+        )
+
+
+class Library(pyozw_common.Library):
+
+    def __init__(self, openzwave):
+
+        build_path = os.path.join(openzwave, 'build')
+
+        build_version_file(openzwave)
+        pyozw_common.build_dll_main(openzwave)
+
+        sources = pyozw_common.get_sources(
+            os.path.abspath(os.path.join(openzwave, 'cpp')),
+            ignore=['unix', 'winrt', 'mac', 'linux', 'examples', 'libusb']
+        )
+
+        define_macros = [
+            ('WIN32', 1),
+            ('_MBCS', 1),
+            ('_LIB', 1),
+            ('USE_HID', 1),
+            ('_MT', 1),
+            ('_DLL', 1),
+            ('OPENZWAVE_MAKEDLL', 1)
+        ]
+
+        if pyozw_common.DEBUG_BUILD:
+            define_macros += [('DEBUG', 1)]
+        else:
+            define_macros += [('NDEBUG', 1)]
+
+        if environment.platform == 'x64':
+            define_macros += [('WIN64', 1)]
+
+        library_dirs = [
+            os.path.join(os.path.dirname(sys.executable), 'libs')
+        ]
+
+        libraries = ['setupapi', pyozw_common.PYTHON_LIB]
+        extra_compile_args = [
+            # Enables function-level linking.
+            '/Gy',
+            # Creates fast code.
+            '/O2',
+            # Uses the __cdecl calling convention (x86 only).
+            '/Gd',
+            # Omits frame pointer (x86 only).
+            '/Oy',
+            # Generates intrinsic functions.
+            '/Oi',
+            # Forces writes to the program database (PDB) file to be
+            # serialized through MSPDBSRV.EXE.
+            '/FS',
+
+            # Renames program database file.
+            '/Fd"{0}\\lib_build\\OpenZWave.pdb"'.format(build_path),
+            # Specify floating-point behavior.
+            '/fp:precise',
+            # Specifies standard behavior
+            '/Zc:inline',
+            # Specifies standard behavior
+            '/Zc:wchar_t',
+            # Specifies standard behavior
+            '/Zc:forScope',
+            # I cannot remember what this does. I do know it does get rid of
+            # a compiler warning
+            '/EHsc',
+            # compiler warnings to ignore
+            '/wd4251',
+            '/wd4244',
+            '/wd4101',
+            '/wd4267',
+            '/wd4996',
+
+        ]
+        # not used but here for completeness.
+        extra_link_args = [
+            '/IGNORE:4098',
+            '/MACHINE:' + environment.platform.upper(),
+            '/NOLOGO',
+            '/SUBSYSTEM:WINDOWS'
+        ]
+
+        include_dirs = [
+            openzwave + '\\cpp\\src',
+            openzwave + '\\cpp\\tinyxml',
+            openzwave + '\\cpp\\hidapi\\hidapi',
+        ]
+
+        pyozw_common.Library.__init__(
+            self,
+            openzwave,
+            sources=sources,
+            define_macros=define_macros,
+            libraries=libraries,
+            library_dirs=library_dirs,
+            include_dirs=include_dirs,
+            extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args
+        )
+
+    def install(self, command_class):
+        pass
+
+    def build(self, command_class):
+        objects = []
+        thread_event = threading.Event()
+
+        def do(files):
+            objs = command_class.compiler.compile(
+                files,
+                output_dir=command_class.build_temp,
+                macros=self.define_macros,
+                include_dirs=self.include_dirs,
+                extra_preargs=self.extra_compile_args,
+                debug=command_class.debug
             )
 
-        with open(os.path.join(project_path, 'OpenZWave.sln'), 'w') as f:
-            f.write(sln)
+            objects.extend(objs)
 
-    solution_path = os.path.join(project_path, 'OpenZWave.sln')
+            threads.remove(threading.current_thread())
 
-    return (
-        solution_path,
-        build_path,
-        msbuild_path,
-        msbuild_version,
-        target_platform,
-        platform_toolset,
-        tools_version,
-        sdk_installation_folder
-    )
+            if not threads:
+                thread_event.set()
 
+        sources = self.sources[:]
 
-def update_vs_project(path, tools_version, platform_toolset, target_platform):
-    from xml.etree import ElementTree
+        split_files = []
+        num_files = int(round(len(sources) / 10))
 
-    vcxproj_xmlns = 'http://schemas.microsoft.com/developer/msbuild/2003'
-    ElementTree.register_namespace('', vcxproj_xmlns)
+        while sources:
+            try:
+                split_files += [sources[:num_files]]
+                sources = sources[num_files:]
+            except IndexError:
+                split_files += [sources[:]]
+                del sources[:]
 
-    with open(path, 'r') as f:
-        vcxproj = f.read()
+        threads = []
 
-    # the original xml file contains some characters that the xml parser
-    # does not like, these are non human readable characters and they do not
-    # need to exist. So we remove them.
-    for char in (187, 191, 239):
-        vcxproj = vcxproj.replace(chr(char), '')
+        for fls in split_files:
 
-    root = ElementTree.fromstring(vcxproj)
+            while len(threads) >= 8:
+                thread_event.wait(0.1)
 
-    vcxproj_xmlns = '{' + vcxproj_xmlns + '}'
+            t = threading.Thread(target=do, args=(fls,))
+            t.daemon = True
+            threads += [t]
+            t.start()
 
-    # there are only 3 things that need to get changed once the solution has
-    # been fully updated. the tools version, the platform teeolset
-    # and the windows target platform. if a cached version of openzwave is used
-    # there is no need to create a whole new solution. so what we do is we set
-    # an attribute in the root of the xml to inform us if the file has been
-    # upgraded already.
+        thread_event.wait()
 
-    root.attrib['ToolsVersion'] = tools_version
+        command_class.compiler.create_static_lib(
+            objects,
+            self.name,
+            output_dir=command_class.build_clib,
+            debug=command_class.debug
+        )
 
-    for node in root.findall(vcxproj_xmlns + 'PropertyGroup'):
-        if (
-            'Label' in node.attrib and
-            node.attrib['Label'] == 'Configuration'
-        ):
-            for sub_node in node:
-                if (
-                    sub_node.tag.replace(vcxproj_xmlns, '') ==
-                    'PlatformToolset'
-                ):
-                    sub_node.text = platform_toolset
-                    break
-            else:
-                sub_node = ElementTree.Element('PlatformToolset')
-                sub_node.text = platform_toolset
-                node.append(sub_node)
-
-    for node in root.findall(vcxproj_xmlns + 'PropertyGroup'):
-        if 'Label' in node.attrib and node.attrib['Label'] == 'Globals':
-            for sub_node in node:
-                if (
-                    sub_node.tag.replace(vcxproj_xmlns, '') ==
-                    'WindowsTargetPlatformVersion'
-                ):
-                    sub_node.text = target_platform
-                    break
-            else:
-                sub_node = ElementTree.Element('WindowsTargetPlatformVersion')
-                sub_node.text = target_platform
-                node.append(sub_node)
-
-    # this function is the core of upgrading the solution. It burrows down
-    # into a node through each layer and makes a copy. this copy gets modified
-    # to become an x64 version. the copy gets returned and then added to the
-    # xml file
-
-    def iter_node(old_node):
-        new_node = ElementTree.Element(old_node.tag)
-        if old_node.text is not None:
-            new_node.text = old_node.text.replace('Win32', 'x64')
-
-        for key, value in old_node.attrib.items():
-            new_node.attrib[key] = value.replace('Win32', 'x64')
-        for old_sub_node in old_node:
-            new_node.append(iter_node(old_sub_node))
-        return new_node
-
-    # here is the testing to se if the file has been updated before.
-    if 'PythonOpenZWave' not in root.attrib:
-        update = True
-        root.attrib['PythonOpenZWave'] = 'True'
-        i = 0
-
-        for node in root[:]:
-            tag = node.tag.replace(vcxproj_xmlns, '')
-
-            if (
-                tag == 'ItemGroup' and
-                'Label' in node.attrib and
-                node.attrib['Label'] == 'ProjectConfigurations'
-            ):
-                for sub_item in node[:]:
-                    node.append(iter_node(sub_item))
-
-            if (
-                tag == 'PropertyGroup' and
-                'Label' in node.attrib and
-                node.attrib['Label'] == 'Configuration'
-            ):
-                root.insert(i, iter_node(node))
-                i += 1
-
-            if (
-                tag == 'ImportGroup' and
-                'Label' in node.attrib and
-                node.attrib['Label'] == 'PropertySheets'
-            ):
-                root.insert(i, iter_node(node))
-                i += 1
-
-            if (
-                tag == 'PropertyGroup' and
-                not node.attrib.keys()
-            ):
-                j = 0
-                for sub_item in node[:]:
-                    if (
-                        sub_item.tag.replace(vcxproj_xmlns, '') !=
-                        '_ProjectFileVersion'
-                    ):
-                        node.insert(j, iter_node(sub_item))
-                    j += 1
-
-            if tag == 'ItemDefinitionGroup':
-                root.insert(i, iter_node(node))
-                i += 1
-            i += 1
-    else:
-        update = False
-
-    with open(path, 'w')as f:
-        f.write(xml_tostring(root, vcxproj_xmlns))
-
-    # we return if the file was updated or not. this is a flag that tells up
-    # if we need to update the sln file.
-    return update
-
-
-# this is a custom xml writer. it recursively iterates through an
-# ElementTree object creating a formatted string that is as close as i can
-# get it to what Visual Studio creates. I did this for consistency as well
-# as ease of bug testing
-
-def xml_tostring(node, xmlns, indent=''):
-    tag = node.tag.replace(xmlns, '')
-    no_text = node.text is None or not node.text.strip()
-
-    if indent:
-        output = ''
-    else:
-        output = '<?xml version="1.0" encoding="utf-8"?>\n'
-        if xmlns:
-            node.attrib['xmlns'] = xmlns.replace('{', '').replace('}', '')
-
-    if no_text and not list(node) and not node.attrib.keys():
-        output += '{0}<{1} />\n'.format(indent, tag)
-    else:
-        output += '{0}<{1}'.format(indent, tag)
-
-        for key in sorted(node.attrib.keys()):
-            output += ' {0}="{1}"'.format(key, str(node.attrib[key]))
-
-        if not list(node) and no_text:
-            output += ' />\n'
-        elif not no_text and not list(node):
-            output += '>{0}</{1}>\n'.format(node.text, tag)
-        elif list(node) and no_text:
-            output += '>\n'
-            for item in node:
-                output += xml_tostring(item, xmlns, indent + '  ')
-            output += '{0}</{1}>\n'.format(indent, tag)
-        else:
-            output += '>\n  {0}{1}\n'.format(indent, node.text)
-            for item in node:
-                output += xml_tostring(item, xmlns, indent + '  ')
-            output += '{0}</{1}>\n'.format(indent, tag)
-    return output
-
-
-# because we no longer use devenv in favor of msbuild there are only 2 commands
-# needed.
-# one for clean and the other to build
-def get_clean_command(msbuild_path, solution_path, build_type, arch, **_):
-    clean_template = (
-        '"{msbuild_path}" '
-        '"{solution_path}" '
-        '/property:Configuration={build_type} '
-        '/property:Platform={arch} '
-        '/t:Clean '
-    )
-    clean_command = clean_template.format(
-        msbuild_path=msbuild_path,
-        solution_path=solution_path,
-        build_type=build_type,
-        arch=arch
-    )
-
-    return clean_command
-
-
-def get_build_command(msbuild_path, solution_path, build_type, arch, **_):
-    build_template = (
-        '"{msbuild_path}" '
-        '"{solution_path}" '
-        '/property:Configuration={build_type} '
-        '/property:Platform={arch} '
-        '/t:Build'
-    )
-
-    build_command = build_template.format(
-        msbuild_path=msbuild_path,
-        solution_path=solution_path,
-        build_type=build_type,
-        arch=arch
-    )
-
-    return build_command
-
-
-def get_system_context(
-    ctx,
-    options,
-    openzwave="openzwave",
-    static=False,
-    debug=False
-):
-
-
-    if debug:
-        print("get_system_context for windows")
-
-    # one feature i added is building a debugging version, this is only going
-    # to happen if sys.executable ends with _d which identifies that the python
-    # interpreter is a debugging build.
-
-    if static:
-        if os.path.splitext(sys.executable)[0].endswith('_d'):
-            options['build_type'] = 'Debug'
-            ctx['define_macros'] += [('_DEBUG', 1)]
-            ctx['libraries'] += ["setupapi", "msvcrtd", "ws2_32", "dnsapi"]
-        else:
-            options['build_type'] = 'Release'
-            ctx['libraries'] += ["setupapi", "msvcrt", "ws2_32", "dnsapi"]
-    else:
-        if os.path.splitext(sys.executable)[0].endswith('_d'):
-            options['build_type'] = 'DebugDLL'
-            ctx['define_macros'] += [('_DEBUG', 1)]
-            ctx['libraries'] += ["setupapi", "msvcrtd", "ws2_32", "dnsapi"]
-        else:
-            options['build_type'] = 'ReleaseDLL'
-            ctx['libraries'] += ["setupapi", "msvcrt", "ws2_32", "dnsapi"]
-
-    if PYTHON64:
-        options['arch'] = "x64"
-    else:
-        options['arch'] = 'Win32'
-
-    (
-        solution_path,
-        build_path,
-        msbuild_path,
-        msbuild_version,
-        target_platform,
-        platform_toolset,
-        tools_version,
-        sdk_installation_folder
-    ) = setup_build_environment(openzwave, options['build_type'])
-
-    options['msbuild_path'] = msbuild_path
-    options['solution_path'] = solution_path
-    options['build_path'] = build_path
-    options['msbuild_version'] = msbuild_version
-    options['target_platform'] = target_platform
-    options['platform_toolset'] = platform_toolset
-    options['tools_version'] = tools_version
-    options['sdk_installation_folder'] = sdk_installation_folder
-
-    if debug:
-        print('Platform: %s' % target_platform)
-        print('Platform architecture %s' % ARCH)
-        print('Platform toolset: %s' % platform_toolset)
-        print('MSBuild path: %s' % msbuild_path)
-        print('MSBuild version: %0.1f' % msbuild_version)
-        print('MSBuild tools version: %s' % tools_version)
-        print('SDK installation path: %s' % sdk_installation_folder)
-        print("Found options %s" % options)
-
-    cpp_path = os.path.join(openzwave, 'cpp')
-    src_path = os.path.join(cpp_path, 'src')
-
-    if static:
-        ctx['extra_objects'] = [os.path.join(build_path, 'OpenZWave.lib')]
-
-        ctx['include_dirs'] += [
-            src_path,
-            os.path.join(src_path, 'value_classes'),
-            os.path.join(src_path, 'platform'),
-            os.path.join(cpp_path, 'build', 'windows'),
-            build_path,
-        ]
-    else:
-        ctx['libraries'] += ["OpenZWave"]
-
-        ctx['extra_compile_args'] += [
-            src_path,
-            os.path.join(src_path, 'value_classes'),
-            os.path.join(src_path, 'platform'),
-        ]
-
-    ctx['define_macros'] += [
-        ('CYTHON_FAST_PYCCALL', 1),
-        ('_MT', 1),
-        ('_DLL', 1)
-    ]
-
-
-GLOBAL_SELECTION_TEMPLATE = '''		Debug|x64 = Debug|x64
-		DebugDLL|x64 = DebugDLL|x64
-		Release|x64 = Release|x64
-		ReleaseDLL|x64 = ReleaseDLL|x64
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{497F9828-DEC2-4C80-B9E0-AD066CCB587C}.Debug|x64.ActiveCfg = Debug|x64
-		{497F9828-DEC2-4C80-B9E0-AD066CCB587C}.Debug|x64.Build.0 = Debug|x64
-		{497F9828-DEC2-4C80-B9E0-AD066CCB587C}.DebugDLL|x64.ActiveCfg = DebugDLL|x64
-		{497F9828-DEC2-4C80-B9E0-AD066CCB587C}.DebugDLL|x64.Build.0 = DebugDLL|x64
-		{497F9828-DEC2-4C80-B9E0-AD066CCB587C}.Release|x64.ActiveCfg = Release|x64
-		{497F9828-DEC2-4C80-B9E0-AD066CCB587C}.Release|x64.Build.0 = Release|x64
-		{497F9828-DEC2-4C80-B9E0-AD066CCB587C}.ReleaseDLL|x64.ActiveCfg = ReleaseDLL|x64
-		{497F9828-DEC2-4C80-B9E0-AD066CCB587C}.ReleaseDLL|x64.Build.0 = ReleaseDLL|x64'''
-
-
-GLOBAL_SELECTION_KEY = '''	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution'''
-
-
-def get_openzwave(opzw_dir):
-    url = 'https://codeload.github.com/OpenZWave/open-zwave/zip/master'
-
-    from io import BytesIO
-    try:
-        from urllib2 import urlopen
-    except ImportError:
-        from urllib.request import urlopen
-
-    import zipfile
-
-    base_path = os.path.dirname(__file__)
-
-    print('Downloading openzwave...')
-
-    req = urlopen(url)
-    dest_file = BytesIO(req.read())
-    dest_file.seek(0)
-
-    zip_ref = zipfile.ZipFile(dest_file, 'r')
-    zip_ref.extractall(base_path)
-    zip_ref.close()
-    dest_file.close()
-
-    os.rename(
-        os.path.join(base_path, zip_ref.namelist()[0]),
-        opzw_dir
-    )
+    def clean(self, _):
+        build_path = os.path.join(self.openzwave, 'build')
+        try:
+            shutil.rmtree(build_path)
+        except OSError:
+            pass
 
 
 if __name__ == '__main__':
-    from subprocess import Popen, PIPE
-    from setuptools import setup
-    from distutils.extension import Extension
-
     print("Start pyozw_win")
-
-    ctx = dict(
-        name='libopenzwave',
-        sources=['src-lib\\libopenzwave\\libopenzwave.pyx'],
-        include_dirs=['src-lib\\libopenzwave'],
-        define_macros=[
-            ('PY_LIB_VERSION', pyozw_version),
-            ('PY_SSIZE_T_CLEAN', 1),
-            ('PY_LIB_FLAVOR', 'dev'),
-            ('PY_LIB_BACKEND', 'cython')
-        ],
-        libraries=[],
-        extra_objects=[],
-        extra_compile_args=[],
-        extra_link_args=[],
-        language='c++'
-    )
+    print(environment)
 
     ozw_path = os.path.abspath('openzwave')
 
     if not os.path.exists(ozw_path):
-        get_openzwave('openzwave')
+        pyozw_common.get_openzwave('openzwave')
 
-    options = dict()
+    from distutils.core import setup
+    from Cython.Distutils import build_ext
 
-    get_system_context(
-        ctx,
-        options,
-        openzwave=ozw_path,
-        static=True,
-        debug=True
-    )
-
-    clean = get_clean_command(**options)
-    build = get_build_command(**options)
-
-    def run(command):
-        print('Running command:', command)
-        proc = Popen(
-            command,
-            shell=True,
-            stdout=PIPE,
-            stderr=PIPE,
-            cwd=os.path.split(options['solution_path'])[0],
-        )
-
-        if PY3:
-            dummy_return = b''
-        else:
-            dummy_return = ''
-
-        for line in iter(proc.stdout.readline, dummy_return):
-            if line and PY3:
-                sys.stdout.write(line.decode("utf-8"))
-            elif line:
-                sys.stdout.write(line)
-
-        errcode = proc.returncode
-        print('\n\nerrcode', errcode, '\n\n')
-
-        for line in iter(proc.stderr.readline, dummy_return):
-            if line and PY3:
-                sys.stdout.write(line.decode("utf-8"))
-            elif line:
-                sys.stdout.write(line)
-
-    # run(clean)
-    # run(build)
-
-    print(
-        'Library built in %s using compiler %s for arch %s' %
-        (options['build_path'], options['msbuild_path'], options['arch'])
-    )
+    import time
+    start_time = time.time()
 
     setup(
-        script_args=['build_ext'],
+        script_args=['build'],
         version=pyozw_version,
         name='libopenzwave',
         description='libopenzwave',
         verbose=1,
-        ext_modules=[Extension(**ctx)],
+        ext_modules=[Extension(ozw_path, 'dev', True, 'cython')],
+        libraries=[Library(ozw_path)],
+        cmdclass=dict(
+            build_clib=pyozw_common.build_clib,
+            build_ext=build_ext
+        ),
+        options=dict(
+            build_clib=dict(
+                build_clib="openzwave\\build\\lib_build",
+                build_temp="openzwave\\build\\lib_build\\temp",
+                compiler='msvc'
+            ),
+            build_ext=dict(
+                build_lib="openzwave\\build",
+                build_temp="openzwave\\build\\temp"
+            )
+        )
     )
+    end_time = time.time()
+    print('Total build time:', end_time - start_time, 'seconds')

--- a/pyozw_win.py
+++ b/pyozw_win.py
@@ -101,13 +101,9 @@ class Extension(pyozw_common.Extension):
             '/Oy',
             # Generates intrinsic functions.
             '/Oi',
-            # Forces writes to the program database (PDB) file to be
-            # serialized through MSPDBSRV.EXE.
-            '/FS',
             # Specify floating-point behavior.
             '/fp:precise',
             # Specifies standard behavior
-            '/Zc:inline',
             '/Zc:wchar_t',
             # Specifies standard behavior
             '/Zc:forScope',
@@ -118,7 +114,22 @@ class Extension(pyozw_common.Extension):
             '/wd4996',
             '/wd4244',
             '/wd4005',
+            '/wd4800',
+            '/wd4351',
+            '/wd4273'
         ]
+
+        if environment.visual_c.version > 10.0:
+            # these compiler flags are not valid on
+            # Visual C++ version 10.0 and older
+
+            extra_compile_args += [
+                # Forces writes to the program database (PDB) file to be
+                # serialized through MSPDBSRV.EXE.
+                '/FS',
+                # Specifies standard behavior
+                '/Zc:inline'
+            ]
 
         if pyozw_common.DEBUG_BUILD:
             define_macros += [('_DEBUG', 1)]
@@ -174,7 +185,7 @@ class Library(pyozw_common.Library):
 
     def __init__(self, openzwave):
 
-        build_path = os.path.join(openzwave, 'build')
+        build_path = self.build_path = os.path.join(openzwave, 'build')
 
         build_version_file(openzwave)
         pyozw_common.build_dll_main(openzwave)
@@ -218,16 +229,10 @@ class Library(pyozw_common.Library):
             '/Oy',
             # Generates intrinsic functions.
             '/Oi',
-            # Forces writes to the program database (PDB) file to be
-            # serialized through MSPDBSRV.EXE.
-            '/FS',
-
             # Renames program database file.
             '/Fd"{0}\\lib_build\\OpenZWave.pdb"'.format(build_path),
             # Specify floating-point behavior.
             '/fp:precise',
-            # Specifies standard behavior
-            '/Zc:inline',
             # Specifies standard behavior
             '/Zc:wchar_t',
             # Specifies standard behavior
@@ -241,8 +246,21 @@ class Library(pyozw_common.Library):
             '/wd4101',
             '/wd4267',
             '/wd4996',
-
+            '/wd4351'
         ]
+
+        if environment.visual_c.version > 10.0:
+            # these compiler flags are not valid on
+            # Visual C++ version 10.0 and older
+
+            extra_compile_args += [
+                # Forces writes to the program database (PDB) file to be
+                # serialized through MSPDBSRV.EXE.
+                '/FS',
+                # Specifies standard behavior
+                '/Zc:inline'
+            ]
+
         # not used but here for completeness.
         extra_link_args = [
             '/IGNORE:4098',
@@ -273,6 +291,11 @@ class Library(pyozw_common.Library):
         pass
 
     def build(self, command_class):
+        if os.path.exists(
+            os.path.join(self.build_path + '\\lib_build', 'OpenZWave.lib')
+        ):
+            return
+
         objects = []
         thread_event = threading.Event()
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ You should have received a copy of the GNU General Public License
 along with python-openzwave. If not, see http://www.gnu.org/licenses.
 
 Build process :
-- ask user what to do (zmq way in pip) 
-- or parametrizes it 
+- ask user what to do (zmq way in pip)
+- or parametrizes it
     --dev : use local sources and cythonize way (for python-openzwave devs, ...)
     --embed : use local sources and cpp file (for third parties packagers, ...)
     --git : download openzwave from git (for geeks)
@@ -32,6 +32,7 @@ Build process :
 """
 from setuptools import setup, find_packages
 from distutils.extension import Extension
+from pyozw_common import build_clib
 from pyozw_version import pyozw_version
 from pyozw_setup import LOCAL_OPENZWAVE, SETUP_DIR
 from pyozw_setup import current_template, parse_template, get_dirs, data_files_config, install_requires, build_requires
@@ -51,6 +52,7 @@ setup(
   url='https://github.com/OpenZWave/python-openzwave',
   cmdclass = {
         'build_ext': current_template.build_ext,
+        'build_clib': build_clib,
         'bdist_egg': bdist_egg,
         'build': build,
         'build_openzwave': build_openzwave,
@@ -66,15 +68,15 @@ setup(
         Extension(**current_template.ctx)
     ],
   #ext_modules = cythonize(ext_modules),
-  package_dir = { 'libopenzwave' : 'src-lib', 
-        'python_openzwave' : 'src-python_openzwave/python_openzwave', 
-        'openzwave' : 'src-api/openzwave', 
+  package_dir = { 'libopenzwave' : 'src-lib',
+        'python_openzwave' : 'src-python_openzwave/python_openzwave',
+        'openzwave' : 'src-api/openzwave',
         'pyozwman' : 'src-manager/pyozwman'
         },
   #The following line install config drectory in share/python-openzwave
   #~ data_files = data_files,
-  packages = find_packages('src-lib', exclude=["scripts"]) + 
-        find_packages('src-api', exclude=["scripts"]) + 
+  packages = find_packages('src-lib', exclude=["scripts"]) +
+        find_packages('src-api', exclude=["scripts"]) +
         find_packages('src-manager', exclude=["scripts"]) +
         find_packages('src-python_openzwave', exclude=["scripts"]),
   install_requires = install_requires(),
@@ -97,5 +99,7 @@ setup(
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     ],
+  options = current_template.options,
+  libraries = current_template.library
 
 )

--- a/src-lib/libopenzwave/libopenzwave.pyx
+++ b/src-lib/libopenzwave/libopenzwave.pyx
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #cython: c_string_type=unicode, c_string_encoding=utf8
+#cython: language_level=3
 
 """
 .. module:: libopenzwave


### PR DESCRIPTION
This may or may not pass the tests. we will see. I may have to make some code changes.


allow use of the following Windows C++ compilers
Visual Studio 2008 - to current
Visual C++ 2008 - to current
Visual C++ 2008 Build Tools - to current
Windows SDK 6.0A - to current
.NET 2.0 - to current

We are not limited to only building with VS 2017 anymore.

I also removed the need for being dependant on setuptools. Since setuptools
versions cause major changes in what can be detected in the way of
MSVC compilers i felt it best to write a whole (complete) detection
system. one that does not use setuptools at all.

I removed parsing of a solution file. as this was dependant on having
MSBuild installed. and also could lead to a nightmare of issues depending
on if the solution file was changed or the version of Visual Studio changed.

I now use distutils to build openzwave. This has made the building
process a whole lot faster and less complex without the need for
parsing any files.

Newer versions of cython will throw out a warning of the language level
is not set. I  set this level in the libopenzwave.pyx file to eliminate
this warning. All MSVC compiler warning have been suppressed to provide a
nice clean output.

The whole build system for Windows is not limited to Windows. It can be
used for the rest of the OS's read the comments in pyozw_common.py for
instructions on how to do this.