### PR TITLE
adds better handling of strings/bytes/unicode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 
 WHL_PYTHON2 := $(shell ls dist/*.whl 2>/dev/null|grep ${python_openzwave_version}|grep [0-9]-cp2)
 WHL_PYTHON3 := $(shell ls dist/*.whl 2>/dev/null|grep ${python_openzwave_version}|grep [0-9]-cp3)
- 
+
 ARCHNAME     = python-openzwave-${python_openzwave_version}
 ARCHDIR      = ${ARCHBASE}/${ARCHNAME}
 
@@ -288,7 +288,7 @@ openzwave.gzip:
 	mv master open-zwave-master.zip
 	unzip open-zwave-master.zip
 	mv open-zwave-master openzwave
-	
+
 openzwave/.lib/: openzwave
 	cd openzwave && $(MAKE) -j 4
 
@@ -389,7 +389,7 @@ pypi_package:clean-archive
 	cp -f pyozw_version.py $(ARCHBASE)/python_openzwave/
 	cp -f pyozw_win.py $(ARCHBASE)/python_openzwave/
 	cp -f pyozw_progressbar.py $(ARCHBASE)/python_openzwave/
-	cp -f python_openzwave.egg-info/PKG-INFO $(ARCHBASE)/python_openzwave/	
+	cp -f python_openzwave.egg-info/PKG-INFO $(ARCHBASE)/python_openzwave/
 	-find $(ARCHBASE)/python_openzwave/ -name \*.pyc -delete 2>/dev/null || true
 	-find $(ARCHBASE)/python_openzwave/ -name \*.so -delete 2>/dev/null || true
 	-find $(ARCHBASE)/python_openzwave/ -type d -name \*.egg-info -exec rm -rf '{}' \; 2>/dev/null || true
@@ -435,7 +435,7 @@ validate-pr: uninstall clean update develop
 	@echo
 
 	$(MAKE) venv-dev-autobuild-tests
-	$(MAKE) venv-bdist_wheel-whl-autobuild-tests 
+	$(MAKE) venv-bdist_wheel-whl-autobuild-tests
 	$(MAKE) venv-bdist_wheel-autobuild-tests
 #~ 	$(MAKE) venv-tests
 
@@ -466,8 +466,8 @@ new-version: validate-pr
 	-git commit -m "Update pyozw_version to ${python_openzwave_version}" pyozw_version.py
 	$(MAKE) debch
 	-git commit -m "Update debian version to ${python_openzwave_version}" debian/
-	-$(MAKE) embed_openzave_master 
-	-$(MAKE) pypi_package 
+	-$(MAKE) embed_openzave_master
+	-$(MAKE) pypi_package
 	-git add $(ARCHIVES)/python_openzwave-${python_openzwave_version}.zip && git commit -m "Add new pypi package" $(ARCHIVES)/python_openzwave-${python_openzwave_version}.zip && git push
 	-git add $(ARCHIVES)/open-zwave-master-${python_openzwave_version}.zip && git commit -m "Add new embed package" $(ARCHIVES)/open-zwave-master-${python_openzwave_version}.zip && git push
 	-git checkout $(ARCHIVES)/*
@@ -499,7 +499,7 @@ venv-deps: common-deps
 	apt-get install --force-yes -y python-all python-dev python3-all python3-dev python-virtualenv python-pip
 #~ 	apt-get install --force-yes -y python-wheel-common python3-wheel python-wheel python-pip-whl
 	apt-get install --force-yes -y pkg-config wget unzip zip
-	pip install Cython==0.28.6
+	pip install Cython
 	pip install wheel
 
 docker-deps: common-deps
@@ -507,8 +507,8 @@ docker-deps: common-deps
 	apt-get install --force-yes -y python3-pip python-pip python-wheel python3-wheel python-pip-whl
 	apt-get install --force-yes -y wget unzip zip
 	apt-get install --force-yes -y g++ libudev-dev libyaml-dev
-	pip install Cython==0.28.6
-	pip3 install Cython==0.28.6
+	pip install Cython
+	pip3 install Cython
 
 venv2:
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
@@ -520,7 +520,7 @@ venv2:
 	virtualenv --python=python2 venv2
 	venv2/bin/python --version
 	venv2/bin/pip install nose
-	venv2/bin/pip install Cython==0.28.6 wheel six
+	venv2/bin/pip install Cython wheel six
 	venv2/bin/pip install 'Louie>=1.1'
 	chmod 755 venv2/bin/activate
 	-rm -f src-lib/libopenzwave/libopenzwave.cpp
@@ -531,7 +531,7 @@ venv2:
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
 	@echo
-	
+
 venv3:
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
@@ -542,7 +542,7 @@ venv3:
 	virtualenv --python=python3 venv3
 	venv3/bin/python --version
 	venv3/bin/pip install nose
-	venv3/bin/pip install Cython==0.28.6 wheel six
+	venv3/bin/pip install Cython wheel six
 	venv3/bin/pip install 'PyDispatcher>=2.0.5'
 	chmod 755 venv3/bin/activate
 	-rm -f src-lib/libopenzwave/libopenzwave.cpp
@@ -558,7 +558,7 @@ venv2-dev: venv2 src-lib/libopenzwave/libopenzwave.cpp
 	venv2/bin/python setup-lib.py develop --flavor=dev
 	venv2/bin/python setup-api.py develop
 	venv2/bin/python setup-manager.py develop
-	
+
 venv3-dev: venv3 src-lib/libopenzwave/libopenzwave.cpp
 	venv3/bin/python setup-lib.py develop --flavor=dev
 	venv3/bin/python setup-api.py develop
@@ -566,7 +566,7 @@ venv3-dev: venv3 src-lib/libopenzwave/libopenzwave.cpp
 
 venv2-install: venv2 src-lib/libopenzwave/libopenzwave.cpp
 	venv2/bin/python setup.py install --flavor=dev
-	
+
 venv3-install: venv3 src-lib/libopenzwave/libopenzwave.cpp
 	venv3/bin/python setup.py install --flavor=dev
 
@@ -574,7 +574,7 @@ venv2-shared: venv2 src-lib/libopenzwave/libopenzwave.cpp
 	venv2/bin/python setup-lib.py install --flavor=shared
 	venv2/bin/python setup-api.py install
 	venv2/bin/python setup-manager.py install
-	
+
 venv3-shared: venv3 src-lib/libopenzwave/libopenzwave.cpp
 	venv3/bin/python setup-lib.py install --flavor=shared
 	venv3/bin/python setup-api.py install
@@ -607,7 +607,7 @@ venv2-tests: venv2-dev
 	@echo
 	@echo ==========================================================================================
 	@echo
-	
+
 venv3-tests: venv3-dev
 	@echo
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
@@ -635,14 +635,14 @@ venv-autobuild-tests: clean
 	@echo
 	@echo
 
-	$(MAKE) venv-pypitest-autobuild-tests 
+	$(MAKE) venv-pypitest-autobuild-tests
 	$(MAKE) venv-pypilive-autobuild-tests
-	$(MAKE) venv-embed-autobuild-tests 
-	$(MAKE) venv-bdist_wheel-whl-autobuild-tests 
+	$(MAKE) venv-embed-autobuild-tests
+	$(MAKE) venv-bdist_wheel-whl-autobuild-tests
 	$(MAKE) venv-bdist_wheel-autobuild-tests
-	$(MAKE) venv-pypi-autobuild-tests 
+	$(MAKE) venv-pypi-autobuild-tests
 	$(MAKE) venv-dev-autobuild-tests
-	$(MAKE) venv-git-autobuild-tests 
+	$(MAKE) venv-git-autobuild-tests
 
 	@echo
 	@echo
@@ -664,9 +664,9 @@ venv-continuous-autobuild-tests:
 	-$(MAKE) venv-embed_shared-autobuild-tests
 	-$(MAKE) venv-git-autobuild-tests
 	-$(MAKE) venv-git_shared-autobuild-tests
-	-$(MAKE) venv-bdist_wheel-whl-autobuild-tests 
+	-$(MAKE) venv-bdist_wheel-whl-autobuild-tests
 	-$(MAKE) venv-bdist_wheel-autobuild-tests
-	-$(MAKE) venv-pypi-autobuild-tests 
+	-$(MAKE) venv-pypi-autobuild-tests
 
 	@echo
 	@echo
@@ -709,7 +709,7 @@ venv-git-autobuild-tests: venv-clean venv2 venv3
 	venv3/bin/python setup-lib.py install --flavor=git
 	venv3/bin/python setup-api.py install
 	venv3/bin/nosetests --verbose tests/lib/autobuild tests/api/autobuild
-	venv3/bin/python  venv3/bin/pyozw_check	
+	venv3/bin/python  venv3/bin/pyozw_check
 	venv3/bin/python venv3/bin/pyozw_check -o raw|grep '(git-'
 
 	@echo
@@ -877,7 +877,7 @@ venv-git_shared-autobuild-tests: venv-clean venv2 venv3
 	$(MAKE) uninstall
 	$(MAKE) uninstallso
 	-pkg-config --libs libopenzwave
-	
+
 	@echo
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
 	@echo
@@ -945,7 +945,7 @@ venv-embed-autobuild-tests: venv-clean venv2 venv3
 	venv2/bin/python setup.py install --flavor=embed
 	venv2/bin/nosetests --verbose tests/lib/autobuild tests/api/autobuild tests/manager/autobuild
 	test -f venv2/lib/python*/site-packages/libopenzwave*.so
-	venv2/bin/python  venv2/bin/pyozw_check	
+	venv2/bin/python  venv2/bin/pyozw_check
 	venv2/bin/python venv2/bin/pyozw_check -o raw|grep '(embed-'
 
 	@echo
@@ -963,7 +963,7 @@ venv-embed-autobuild-tests: venv-clean venv2 venv3
 	venv3/bin/python setup.py install --flavor=embed
 	venv3/bin/nosetests --verbose tests/lib/autobuild tests/api/autobuild tests/manager/autobuild
 	test -f venv3/lib/python*/site-packages/libopenzwave*.so
-	venv3/bin/python  venv3/bin/pyozw_check	
+	venv3/bin/python  venv3/bin/pyozw_check
 	venv3/bin/python venv3/bin/pyozw_check -o raw|grep '(embed-'
 
 	-rm -f libopenzwave*.so
@@ -997,7 +997,7 @@ venv-embed_shared-autobuild-tests: venv-clean venv2 venv3
 	venv2/bin/python setup.py install --flavor=embed_shared
 	venv2/bin/nosetests --verbose tests/lib/autobuild tests/api/autobuild tests/manager/autobuild
 	test -f venv2/lib/python*/site-packages/libopenzwave*.so
-	venv2/bin/python  venv2/bin/pyozw_check	
+	venv2/bin/python  venv2/bin/pyozw_check
 	venv2/bin/python venv2/bin/pyozw_check -o raw|grep '(embed_shared-'
 
 	@echo
@@ -1014,7 +1014,7 @@ venv-embed_shared-autobuild-tests: venv-clean venv2 venv3
 	venv3/bin/python setup.py install --flavor=embed_shared
 	venv3/bin/nosetests --verbose tests/lib/autobuild tests/api/autobuild tests/manager/autobuild
 	test -f venv3/lib/python*/site-packages/libopenzwave*.so
-	venv3/bin/python  venv3/bin/pyozw_check	
+	venv3/bin/python  venv3/bin/pyozw_check
 	venv3/bin/python venv3/bin/pyozw_check -o raw|grep '(embed_shared-'
 
 	-rm -f libopenzwave*.so
@@ -1048,7 +1048,7 @@ venv-pypi-autobuild-tests: venv-clean pypi_package
 	venv2/bin/pip install "Cython"
 	. venv2/bin/activate && cd tmp/pypi_test/python_openzwave && python setup.py install
 	. venv2/bin/activate && cd tmp/pypi_test/python_openzwave && python setup.py bdist_wheel --flavor=git
-	
+
 	@echo
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
 	@echo
@@ -1076,10 +1076,10 @@ venv-pypi-autobuild-tests: venv-clean pypi_package
 	@echo
 
 	. venv3/bin/activate && cd tmp/pypi_test/python_openzwave && python setup.py bdist_wheel --flavor=git
-	
-	-mkdir -p dist	
+
+	-mkdir -p dist
 	cp tmp/pypi_test/python_openzwave/dist/*.whl dist/
-	
+
 	$(MAKE) venv-bdist_wheel-autobuild-tests
 
 	@echo
@@ -1107,7 +1107,7 @@ venv-pypi-autobuild-tests: venv-clean pypi_package
 	. venv3/bin/activate && python venv3/bin/pyozw_check
 	. venv3/bin/activate && cd tmp/pypi_test/python_openzwave && python setup.py clean --all --flavor=git
 	find venv3/lib/ -iname device_classes.xml -type f -print|cat
-	
+
 	@echo
 	@echo
 	@echo "Tests for venv-pypi-autobuild-tests done."
@@ -1123,7 +1123,7 @@ venv-bdist_wheel-whl-autobuild-tests: venv-clean venv2 venv3
 	@echo "Create tests whl for venv-bdist_wheel-autobuild-tests."
 	@echo
 	@echo
-	
+
 	-rm -f dist/*.whl
 
 	@echo
@@ -1147,7 +1147,7 @@ venv-bdist_wheel-whl-autobuild-tests: venv-clean venv2 venv3
 
 	venv3/bin/python setup.py install --flavor=git
 	venv3/bin/python setup.py bdist_wheel --flavor=git
-	
+
 	@echo
 	@echo
 	@echo "Tests for venv-bdist_wheel-autobuild-tests created."
@@ -1171,7 +1171,7 @@ venv-bdist_wheel-autobuild-tests: venv-clean
 	@echo
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
 	@echo
-	
+
 	-rm -Rf venv2
 	virtualenv --python=python2 venv2
 	chmod 755 venv2/bin/activate
@@ -1182,7 +1182,7 @@ venv-bdist_wheel-autobuild-tests: venv-clean
 	venv2/bin/pip install "nose"
 #~ 	venv2/bin/pip install "Cython"
 	venv2/bin/pip install "urwid>=1.1.1"
-	
+
 	venv2/bin/pip install dist/python_openzwave-${python_openzwave_version}-cp2*
 	venv2/bin/nosetests --verbose tests/lib/autobuild tests/api/autobuild tests/manager/autobuild
 	find venv2/lib/ -iname device_classes.xml -type f -exec cat '{}' \;|grep open-zwave
@@ -1214,7 +1214,7 @@ venv-bdist_wheel-autobuild-tests: venv-clean
 	test -f venv3/lib/python*/site-packages/libopenzwave*.so
 	venv3/bin/pip uninstall -y "${WHL_PYTHON3}"
 	#test ! -f venv3/lib/python*/site-packages/libopenzwave*.so
-	
+
 	@echo
 	@echo
 	@echo "Tests for venv-bdist_wheel-autobuild-tests done."
@@ -1248,7 +1248,7 @@ venv-dev-autobuild-tests: venv-clean venv2 venv3 src-lib/libopenzwave/libopenzwa
 	venv2/bin/python setup-api.py install
 	venv2/bin/python setup-manager.py install
 	venv2/bin/nosetests --verbose tests/lib/autobuild tests/api/autobuild tests/manager/autobuild
-	venv2/bin/python  venv2/bin/pyozw_check	
+	venv2/bin/python  venv2/bin/pyozw_check
 
 	@echo
 	@echo ////////////////////////////////////////////////////////////////////////////////////////////
@@ -1268,8 +1268,8 @@ venv-dev-autobuild-tests: venv-clean venv2 venv3 src-lib/libopenzwave/libopenzwa
 	venv3/bin/python setup-api.py install
 #~ 	venv3/bin/python setup-manager.py install
 	venv3/bin/nosetests --verbose tests/lib/autobuild tests/api/autobuild
-	venv3/bin/python  venv3/bin/pyozw_check	
-	
+	venv3/bin/python  venv3/bin/pyozw_check
+
 	-rm -f libopenzwave*.so
 	@echo
 	@echo
@@ -1308,7 +1308,7 @@ venv-shared-autobuild-tests: venv-clean venv2-shared venv3-shared
 
 	venv3/bin/nosetests --verbose tests/lib/autobuild tests/api/autobuild
 	venv3/bin/python  venv3/bin/pyozw_check
-	
+
 	@echo
 	@echo
 	@echo "Tests for venv-shared-autobuild-tests done."
@@ -1318,7 +1318,7 @@ venv-shared-autobuild-tests: venv-clean venv2-shared venv3-shared
 	@echo
 
 buildso: openzwave/.lib/
-	cd openzwave && $(MAKE) install    
+	cd openzwave && $(MAKE) install
 
 uninstallso:
 	rm -f /usr/local/lib/x86_64-linux-gnu/pkgconfig/libopenzwave.pc

--- a/pyozw_setup.py
+++ b/pyozw_setup.py
@@ -257,13 +257,13 @@ class Template(object):
         if sys.platform.startswith("win"):
             return ['Cython']
         else:
-            return ['Cython==0.28.6']
+            return ['Cython']
 
     def build_requires(self):
         if sys.platform.startswith("win"):
             return ['Cython']
         else:
-            return ['Cython==0.28.6']
+            return ['Cython']
 
     def build(self):
         if len(self.ctx['extra_objects']) == 1 and os.path.isfile(self.ctx['extra_objects'][0]):

--- a/src-lib/libopenzwave/libopenzwave.pyx
+++ b/src-lib/libopenzwave/libopenzwave.pyx
@@ -74,6 +74,9 @@ logger.addHandler(NullHandler())
 
 from pkg_resources import get_distribution, DistributionNotFound
 
+
+PY3 = sys.version_info[0] > 2
+
 cdef extern from 'pyversion.h':
     string PY_LIB_VERSION_STRING
     string PY_LIB_FLAVOR_STRING
@@ -659,6 +662,17 @@ def configPath():
                 return os.path.join(libopenzwave_location, PY_OZWAVE_CONFIG_DIRECTORY)
     return None
 
+
+def  convert_string(s):
+    if PY3:
+        if not isinstance(s, bytes):
+            s = s.encode('utf-8')
+    else:
+        if not isinstance(s, unicode):
+            s = s.decode('utf-8')
+    return s
+
+
 cdef class PyOptions:
     """
     Manage options manager
@@ -691,25 +705,27 @@ cdef class PyOptions:
         if os.path.exists(config_path):
             if not os.path.exists(os.path.join(config_path, "zwcfg.xsd")):
                 raise LibZWaveException("Can't retrieve zwcfg.xsd from %s" % config_path)
-            self._config_path = config_path
+
+            self._config_path = convert_string(config_path)
         else:
             raise LibZWaveException("Can't find config directory %s" % config_path)
         if user_path is None:
             user_path = "."
         if os.path.exists(user_path):
             if os.access(user_path, os.W_OK)==True and os.access(user_path, os.R_OK)==True:
-                self._user_path = user_path
+                self._user_path = convert_string(user_path)
             else:
                 raise LibZWaveException("Can't write in user directory %s" % user_path)
         else:
             raise LibZWaveException("Can't find user directory %s" % user_path)
         if cmd_line is None:
             cmd_line=""
-        self._cmd_line = cmd_line
+
+        self._cmd_line = convert_string(cmd_line)
         self.create(self._config_path, self._user_path, self._cmd_line)
 
 
-    def create(self, str a, str b, str c):
+    def create(self, a, b, c):
         """
         .. _createoptions:
 
@@ -725,6 +741,10 @@ cdef class PyOptions:
         :see: destroyoptions_
 
         """
+        a = convert_string(a)
+        b = convert_string(b)
+        c = convert_string(c)
+
         self.options = CreateOptions(
             str_to_cppstr(a), str_to_cppstr(b), str_to_cppstr(c))
         return True
@@ -779,7 +799,7 @@ cdef class PyOptions:
         '''
         return self.options.AreLocked()
 
-    def addOptionBool(self, str name, value):
+    def addOptionBool(self, name, value):
         """
         .. _addOptionBool:
 
@@ -795,9 +815,10 @@ cdef class PyOptions:
         :see: addOption_, addOptionInt_, addOptionString_
 
         """
+        name = convert_string(name)
         return self.options.AddOptionBool(str_to_cppstr(name), value)
 
-    def addOptionInt(self, str name, value):
+    def addOptionInt(self, name, value):
         """
         .. _addOptionInt:
 
@@ -813,9 +834,10 @@ cdef class PyOptions:
         :see: addOption_, addOptionBool_, addOptionString_
 
         """
+        name = convert_string(name)
         return self.options.AddOptionInt(str_to_cppstr(name), value)
 
-    def addOptionString(self, str name, str value, append=False):
+    def addOptionString(self, name, value, append=False):
         """
         .. _addOptionString:
 
@@ -835,6 +857,9 @@ cdef class PyOptions:
         :see: addOption_, addOptionBool_, addOptionInt_
 
         """
+        name = convert_string(name)
+        value = convert_string(value)
+
         return self.options.AddOptionString(
             str_to_cppstr(name), str_to_cppstr(value), append)
 
@@ -854,9 +879,12 @@ cdef class PyOptions:
         :see: addOptionBool_, addOptionInt_, addOptionString_
 
         """
+        name = convert_string(name)
+
         if name not in PyOptionList:
             return False
         if PyOptionList[name]['type'] == "String":
+            value = convert_string(value)
             return self.addOptionString(name, value)
         elif PyOptionList[name]['type'] == "Bool":
             return self.addOptionBool(name, value)
@@ -878,6 +906,7 @@ cdef class PyOptions:
         :see: getOptionAsBool_, getOptionAsInt_, getOptionAsString_
 
         """
+        name = convert_string(name)
         if name not in PyOptionList:
             return None
         if PyOptionList[name]['type'] == "String":
@@ -902,6 +931,7 @@ cdef class PyOptions:
         :see: getOption_, getOptionAsInt_, getOptionAsString_
 
         """
+        name = convert_string(name)
         cdef bool type_bool
         cret = self.options.GetOptionAsBool(str_to_cppstr(name), &type_bool)
         ret = type_bool if cret==True else None
@@ -921,6 +951,7 @@ cdef class PyOptions:
         :see: getOption_, getOptionAsBool_, getOptionAsString_
 
         """
+        name = convert_string(name)
         cdef int32_t type_int
         cret = self.options.GetOptionAsInt(str_to_cppstr(name), &type_int)
         ret = type_int if cret==True else None
@@ -940,6 +971,7 @@ cdef class PyOptions:
         :see: getOption_, getOptionAsBool_, getOptionAsInt_
 
         """
+        name = convert_string(name)
         cdef string type_string
         cret = self.options.GetOptionAsString(str_to_cppstr(name), &type_string)
         ret = cstr_to_str(type_string.c_str()) if cret==True else None
@@ -1210,7 +1242,7 @@ etc.
 # -----------------------------------------------------------------------------
 # Methods for adding and removing drivers and obtaining basic controller information.
 #
-    def addDriver(self, str serialport):
+    def addDriver(self, serialport):
         '''
 .. _addDriver:
 
@@ -1231,9 +1263,11 @@ Home ID is required by most of the OpenZWave Manager class methods.
 :see: removeDriver_
 
         '''
+        serialport = convert_string(serialport)
+
         self.manager.AddDriver(str_to_cppstr(serialport))
 
-    def removeDriver(self, str serialport):
+    def removeDriver(self, serialport):
         '''
 .. _removeDriver:
 
@@ -1249,6 +1283,7 @@ handled automatically.
 :see: addDriver_
 
         '''
+        serialport = convert_string(serialport)
         self.manager.RemoveDriver(str_to_cppstr(serialport))
 
     def getControllerInterfaceType(self, homeid):
@@ -1562,7 +1597,7 @@ Statistics:
 
        '''
         cdef DriverData_t data
-        self.manager.GetDriverStatistics( homeId, &data );
+        self.manager.GetDriverStatistics( homeId, &data )
         ret = {}
         ret['SOFCnt'] = data.m_SOFCnt
         ret['ACKWaiting'] = data.m_ACKWaiting
@@ -2355,7 +2390,7 @@ data.
         cdef string c_string = self.manager.GetNodeProductId(homeid, nodeid)
         return cstr_to_str(c_string.c_str())
 
-    def setNodeManufacturerName(self, homeid, nodeid, str manufacturerName):
+    def setNodeManufacturerName(self, homeid, nodeid, manufacturerName):
         '''
 .. _setNodeManufacturerName:
 
@@ -2378,10 +2413,11 @@ class Value object.
 :see: getNodeManufacturerName_, getNodeProductName_, setNodeProductName_
 
         '''
+        manufacturerName = convert_string(manufacturerName)
         self.manager.SetNodeManufacturerName(
             homeid, nodeid, str_to_cppstr(manufacturerName))
 
-    def setNodeProductName(self, homeid, nodeid, str productName):
+    def setNodeProductName(self, homeid, nodeid, productName):
         '''
 .. _setNodeProductName:
 
@@ -2404,9 +2440,10 @@ class Value object.
 :see: getNodeProductName_, getNodeManufacturerName_, setNodeManufacturerName_
 
         '''
+        productName = convert_string(productName)
         self.manager.SetNodeProductName(homeid, nodeid, str_to_cppstr(productName))
 
-    def setNodeName(self, homeid, nodeid, str name):
+    def setNodeName(self, homeid, nodeid, name):
         '''
 .. _setNodeName:
 
@@ -2429,9 +2466,10 @@ node name is 16 characters.
 :see: getNodeName_, getNodeLocation_, setNodeLocation_
 
         '''
+        name = convert_string(name)
         self.manager.SetNodeName(homeid, nodeid, str_to_cppstr(name))
 
-    def setNodeLocation(self, homeid, nodeid, str location):
+    def setNodeLocation(self, homeid, nodeid, location):
         '''
 .. _setNodeLocation:
 
@@ -2453,6 +2491,7 @@ Node Naming command class, the new location will be sent to the node.
 :see: getNodeLocation_, getNodeName_, setNodeName_
 
         '''
+        location = convert_string(location)
         self.manager.SetNodeLocation(homeid, nodeid, str_to_cppstr(location))
 
     def setNodeOn(self, homeid, nodeid):
@@ -2876,6 +2915,7 @@ if the Z-Wave message actually failed to get through.  Notification callbacks wi
                 cret = self.manager.SetValue(values_map.at(id), type_short)
                 ret = 1 if cret else 0
             elif datatype == "String":
+                value = convert_string(value)
                 if six.PY3:
                     type_string = str_to_cppstr(value)
                 else:
@@ -2932,7 +2972,7 @@ Gets the user-friendly label for the value
         else :
             return None
 
-    def setValueLabel(self, id, str label):
+    def setValueLabel(self, id, label):
         '''
 .. _setValueLabel:
 
@@ -2945,6 +2985,7 @@ Sets the user-friendly label for the value
 :see: getValueLabel_
 
         '''
+        label = convert_string(label)
         if values_map.find(id) != values_map.end():
             self.manager.SetValueLabel(values_map.at(id), str_to_cppstr(label))
 
@@ -2968,7 +3009,7 @@ Gets the units that the value is measured in.
         else :
             return None
 
-    def setValueUnits(self, id, str unit):
+    def setValueUnits(self, id, unit):
         '''
 .. _setValueUnits:
 
@@ -2981,6 +3022,7 @@ Sets the units that the value is measured in.
 :see: getValueUnits_
 
         '''
+        unit = convert_string(unit)
         if values_map.find(id) != values_map.end():
             self.manager.SetValueUnits(values_map.at(id), str_to_cppstr(unit))
 
@@ -3004,7 +3046,7 @@ Gets a help string describing the value's purpose and usage.
         else :
             return None
 
-    def setValueHelp(self, id, str help):
+    def setValueHelp(self, id, help):
         '''
 .. _setValueHelp:
 
@@ -3017,6 +3059,7 @@ Sets a help string describing the value's purpose and usage.
 :see: getValueHelp_
 
         '''
+        help = convert_string(help)
         if values_map.find(id) != values_map.end():
             self.manager.SetValueHelp(values_map.at(id), str_to_cppstr(help))
 
@@ -4775,6 +4818,7 @@ removeSceneValue_, setSceneValue_, sceneGetValues_
                 cret = self.manager.AddSceneValue(sceneid, values_map.at(id), type_short)
                 ret = 1 if cret else 0
             elif datatype == "String":
+                value = convert_string(value)
                 type_string = string(value)
                 cret = self.manager.AddSceneValue(sceneid, values_map.at(id), type_string)
                 ret = 1 if cret else 0
@@ -4863,6 +4907,7 @@ sceneGetValues_
                 cret = self.manager.SetSceneValue(sceneid, values_map.at(id), type_short)
                 ret = 1 if cret else 0
             elif datatype == "String":
+                value = convert_string(value)
                 type_string = string(value)
                 cret = self.manager.SetSceneValue(sceneid, values_map.at(id), type_string)
                 ret = 1 if cret else 0
@@ -4897,7 +4942,7 @@ sceneGetValues_
         cdef string c_string = self.manager.GetSceneLabel(sceneid)
         return cstr_to_str(c_string.c_str())
 
-    def setSceneLabel(self, sceneid, str label):
+    def setSceneLabel(self, sceneid, label):
         '''
 .. _setSceneLabel:
 
@@ -4913,6 +4958,7 @@ getSceneLabel_, removeSceneValue_, addSceneValue_, setSceneValue_, \
 sceneGetValues_
 
         '''
+        label = convert_string(label)
         self.manager.SetSceneLabel(sceneid, str_to_cppstr(label))
 
     def sceneExists(self, sceneid):

--- a/src-lib/libopenzwave/libopenzwave.pyx
+++ b/src-lib/libopenzwave/libopenzwave.pyx
@@ -668,10 +668,7 @@ def  convert_string(s):
         if isinstance(s, bytes):
             s = s.decode('utf-8')
     else:
-        if sys.platform.startswith('win'):
-            if not isinstance(s, unicode):
-                s = s.decode('utf-8')
-        elif isinstance(s, unicode):
+        if isinstance(s, unicode):
             s = s.encode('utf-8')
     return s
 

--- a/src-lib/libopenzwave/libopenzwave.pyx
+++ b/src-lib/libopenzwave/libopenzwave.pyx
@@ -665,8 +665,8 @@ def configPath():
 
 def  convert_string(s):
     if PY3:
-        if not isinstance(s, bytes):
-            s = s.encode('utf-8')
+        if isinstance(s, bytes):
+            s = s.decode('utf-8')
     else:
         if not isinstance(s, unicode):
             s = s.decode('utf-8')

--- a/src-lib/libopenzwave/libopenzwave.pyx
+++ b/src-lib/libopenzwave/libopenzwave.pyx
@@ -668,8 +668,11 @@ def  convert_string(s):
         if isinstance(s, bytes):
             s = s.decode('utf-8')
     else:
-        if not isinstance(s, unicode):
-            s = s.decode('utf-8')
+        if sys.platform.startswith('win'):
+            if not isinstance(s, unicode):
+                s = s.decode('utf-8')
+        elif isinstance(s, unicode):
+            s = s.encode('utf-8')
     return s
 
 


### PR DESCRIPTION
currently in the libopenzwave.pyx file there are default data types
for str that are set for some of the function/method parameters.
This causes an issue with the test build when running on python 2.
Because a string literal in python 3 by default is unicode (bytes)
everything works as advertised. in python 2 string literals are of
type str(). and because of the marker at the top of the pyx file

#cython: c_string_type=unicode, c_string_encoding=utf8

this is forcing all of the str data types to be unicode.
Now I could go and write a whole second test routine specifically for
python 2. But to me this seems like it is not the proper way to go
about it. Python 2 does not have the best mechanism for dealing with
unicode strings and it can be very confusing. also because everything
is defaulted to str() in python 2. I thought it would be best to grab
the bull by the horns and handle all of the unicode mess internal to
libopenzwave. This is going to make it much easier for the user to be
able to use the library with out having to deal with a bunch of
additional code. especially if their program supports python2 and 3.

It is a real headache to have to decode a path returned by the os module
for something trivial like a logfile location. and if the user is
supporting python 2 and 3 it would add a very large amount of code to
have to deal with issues like this for each and every single
function/method call to python-openzwave.

So what i did was I removed the str data type from the parameters.
I created a function that will check the data type based on the
python version and if it is not either unicode or bytes it will do the
necessary encoding or decoding to make the data the correct type.

The added benefit of doing this is now all of the tests work
properly for python 2 without having to recode the tests.

The API has not changed other then now you can pass str, bytes or unicode
to the functions\methods that would only allow unicode before.

so no changes are made that will affect a users program at all.

the users will be happy. we are happy (no test rewrite to be done).
seems like a win win to me.

I also took into account setting variables that are of type String as
well.