### PR TITLE
adds expanding of $, % and ~ path variables for paths passsed to the Options class

### DIFF
--- a/src-api/openzwave/option.py
+++ b/src-api/openzwave/option.py
@@ -43,6 +43,23 @@ except ImportError:
 logger = logging.getLogger('openzwave')
 logger.addHandler(NullHandler())
 
+
+def _expand_path(path):
+    if path is None:
+        return path
+
+    if '$' in path or '%' in path:
+        path = os.path.expandvars(path)
+
+    if '~' in path:
+        path = path.replace(
+            '~',
+            os.path.expanduser('~')
+        )
+
+    return os.path.abspath(path)
+
+
 class ZWaveOption(libopenzwave.PyOptions):
     """
     Represents a Zwave option used to start the manager.
@@ -79,6 +96,10 @@ class ZWaveOption(libopenzwave.PyOptions):
             except:
                 import sys, traceback
                 raise ZWaveException(u"Error when retrieving device %s : %s" % (device, traceback.format_exception(*sys.exc_info())))
+
+        config_path = _expand_path(config_path)
+        user_path = _expand_path(user_path)
+
         libopenzwave.PyOptions.__init__(self, config_path=config_path, user_path=user_path, cmd_line=cmd_line)
 
     def set_log_file(self, logfile):
@@ -89,6 +110,8 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type logfile: str
 
         """
+
+        logfile = _expand_path(logfile)
         return self.addOptionString("LogFileName", logfile, False)
 
     def set_logging(self, status):


### PR DESCRIPTION
when creating the Options class instance the user has the ability to
specify the location of the user path and config path. I have seen on
numerous occasions (specifically with NIX OS's) the user having a
`~` or `$` in the path. These are convenient to use but unless the
variables are expanded the paths are going to be incorrect. So I added
checking for these variables and performing any needed expansion.

I also added this same check when the log file gets set.

I also make sure that all passed paths are absolute

NOTE: `~` in Windows serves the same purpose as in NIX OS's. it is a
pointer to the currently logged in user home directory
(profile directory on Windows)