### PR TITLE
Serial port auto detection

### DIFF
--- a/src-api/openzwave/option.py
+++ b/src-api/openzwave/option.py
@@ -92,7 +92,7 @@ class ZWaveOption(libopenzwave.PyOptions):
             device = _get_z_stick()
 
         if platform_system() == 'Windows':
-            if not device.startswith('\\\\.\\'):
+            if device and not device.startswith('\\\\.\\'):
                 device = '\\\\.\\' + device
 
             self._device = device

--- a/src-api/openzwave/option.py
+++ b/src-api/openzwave/option.py
@@ -43,6 +43,32 @@ except ImportError:
 logger = logging.getLogger('openzwave')
 logger.addHandler(NullHandler())
 
+
+VENDOR_IDS = ('0658',)
+
+
+def _get_z_stick():
+    try:
+        import serial.tools.list_ports
+    except ImportError:
+        return None
+
+    for port in serial.tools.list_ports.comports(include_links=False):
+        if port.vid is None:
+            continue
+        if port.product is not None and 'Zigbee' in port.product:
+            continue
+        if port.interface is not None and 'Zigbee' in port.interface:
+            continue
+        if port.description is not None and 'Zigbee' in port.description:
+            continue
+
+        for vid in VENDOR_IDS:
+            if vid.upper() == hex(port.vid)[2:].upper().zfill(4):
+                return port.device
+    return None
+
+
 class ZWaveOption(libopenzwave.PyOptions):
     """
     Represents a Zwave option used to start the manager.
@@ -52,7 +78,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         """
         Create an option object and check that parameters are valid.
 
-        :param device: The device to use
+        :param device: The device to use or None for auto detection (pyserial needs to be installed for auto detection).
         :type device: str
         :param config_path: The openzwave config directory. If None, try to configure automatically.
         :type config_path: str
@@ -62,7 +88,13 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type cmd_line: str
 
         """
+        if device is None:
+            device = _get_z_stick()
+
         if platform_system() == 'Windows':
+            if not device.startswith('\\\\.\\'):
+                device = '\\\\.\\' + device
+
             self._device = device
         else:
             #For linux

--- a/src-python_openzwave/python_openzwave/scripts/pyozw_check.py
+++ b/src-python_openzwave/python_openzwave/scripts/pyozw_check.py
@@ -65,7 +65,7 @@ def imports(args):
         time.sleep(0.5)
         print("Try to import openzwave (API)")
         import openzwave
-        
+
     elif args.output == 'raw':
         import libopenzwave
         from libopenzwave import PyLogLevels
@@ -96,7 +96,7 @@ def zwcallback(zwargs):
     if notify_type == "DriverReady":
         global home_id
         home_id = zwargs['homeId']
-    
+
     #~ print("Received {0} : {1}".format(notify_type,libopenzwave.PyNotifications[notify_type].doc))
     if args.output == 'txt':
         print("Received {0}".format(notify_type))
@@ -255,11 +255,11 @@ def list_nodes(args):
     print("Stop network")
     network.stop()
     print("Exit")
-                
+
 def pyozw_parser():
     parser = argparse.ArgumentParser(description='Run python_openzwave basics checks.')
     parser.add_argument('-o', '--output', action='store', help='The format (txt, raw, ...)', choices=['txt', 'raw'], default='txt')
-    parser.add_argument('-d', '--device', action='store', help='The device port', default='/dev/ttyUSB0')
+    parser.add_argument('-d', '--device', action='store', help='The device port', default=None)
     parser.add_argument('-m', '--imports', action='store_true', help='Import all libs', default=True)
     parser.add_argument('-i', '--init_device', action='store_true', help='Intialize the device', default=False)
     parser.add_argument('-l', '--list_nodes', action='store_true', help='List the nodes on zwave network', default=False)
@@ -278,7 +278,7 @@ def main():
         list_nodes(args)
     elif args.imports:
         imports(args)
-        
+
 if __name__ == '__main__':
     main()
 

--- a/src-python_openzwave/python_openzwave/scripts/pyozw_shell.py
+++ b/src-python_openzwave/python_openzwave/scripts/pyozw_shell.py
@@ -49,7 +49,7 @@ def main():
         '-d', '--device',
         dest='device',
         type="str",
-        default="/dev/ttyUSB0",
+        default=None,
         help="The path to your ZWave device")
 
     parser.add_option(


### PR DESCRIPTION
This currently only works for Silicon Labs/Sigma Designs chipsets at the moment.
I do not know the hardware id's of any other chipset manufacturers, Additional hardware iid's can be added to the detection by adding them to `src-api/openzwave/option.VENDOR_IDS`

This change makes use of pyserial to enumerate the available ports on the OS and then
checks the hardware id of the port. pyserial is not listed as a
requirement as it would be an optional install the program tries to
import pyserial and if it cannot import it then it will continue
along it's way.

the auto detection gets activated if the `device` parameter of `option.ZWaveOption` is set to `None`

Windows like most operating systems do function the same in terms of a
path to the serial device. on NIX based systems it is a literal file
path where as in Windows it is a virtual path (namespace object).
Unless the user is very familiar with the Windows OS they are not going
to know to prefix the "COM" port with "\\\\.\\". I added in the
prefixing of the "COM" port if it has not been done.

These additions will make it easier for the user to get up and running. 
It is also going to make it easier for the library to be integrated into other programs. The author that is integrating this library is not going to have to worry about things like Windows serial ports or having the user know what port to enter. sometimes it is the simple things that can make people really happy when using a piece of software :smile:

